### PR TITLE
금액 사용(Transaction) #12

### DIFF
--- a/src/main/java/com/intelliJ_JO/modam/ModamApplication.java
+++ b/src/main/java/com/intelliJ_JO/modam/ModamApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class ModamApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ModamApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(ModamApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/intelliJ_JO/modam/domain/member/entity/Member.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/member/entity/Member.java
@@ -1,0 +1,84 @@
+package com.intelliJ_JO.modam.domain.member.entity;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "member")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(name = "user_id", nullable = false, unique = true)
+    private String userId;
+
+    @Column(name = "pw_hash", nullable = false)
+    private String pwHash;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private boolean agree;
+
+    @Column(nullable = false)
+    private boolean notif;
+
+    @Column(name = "en_first", nullable = false)
+    private String enFirst;
+
+    @Column(name = "en_last", nullable = false)
+    private String enLast;
+
+    @Column(name = "bank_name", nullable = false)
+    private String bankName;
+
+    @Column(name = "pers_acct_no", nullable = false)
+    private String persAcctNo;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(nullable = false)
+    private boolean active;
+
+    @Column(nullable = false)
+    private String address;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberRole role = MemberRole.USER;
+
+
+    @Column(name = "phone_no", nullable = false)
+    private String phoneNo;
+
+    @Column(name = "profile_img")
+    private String profileImg;
+
+    @Column(nullable = false)
+    private String rrn;
+}

--- a/src/main/java/com/intelliJ_JO/modam/domain/member/entity/MemberRole.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/member/entity/MemberRole.java
@@ -1,0 +1,5 @@
+package com.intelliJ_JO.modam.domain.member.entity;
+
+public enum MemberRole {
+    USER, ADMIN
+}

--- a/src/main/java/com/intelliJ_JO/modam/domain/transaction/controller/TransactionController.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/transaction/controller/TransactionController.java
@@ -1,0 +1,40 @@
+package com.intelliJ_JO.modam.domain.transaction.controller;
+
+import com.intelliJ_JO.modam.domain.transaction.dto.request.TransactionRequestDto;
+import com.intelliJ_JO.modam.domain.transaction.dto.response.TransactionResponseDto;
+import com.intelliJ_JO.modam.domain.transaction.service.TransactionService;
+import com.intelliJ_JO.modam.global.response.GlobalResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/transactions")
+@RequiredArgsConstructor
+public class TransactionController {
+
+    private final TransactionService transactionService;
+
+    // 1. 거래 내역 생성 (입금/출금/결제)
+    @PostMapping
+    public ResponseEntity<GlobalResponse<Void>> createTransaction(@Valid @RequestBody TransactionRequestDto requestDto) {
+        transactionService.createTransaction(requestDto);
+        return ResponseEntity.ok(GlobalResponse.ok("거래가 성공적으로 처리되었습니다."));
+    }
+
+    // 2. 🌟 무한 스크롤 기반 거래 내역 조회
+    @GetMapping("/{accountId}")
+    public ResponseEntity<GlobalResponse<List<TransactionResponseDto>>> getTransactions(
+            @PathVariable Long accountId,
+            @RequestParam(required = false) Long lastTransactionId, // 프론트에서 넘겨주는 마지막으로 본 거래내역 ID
+            @RequestParam(defaultValue = "10") int size) {          // 한 번에 가져올 개수 (기본 10개)
+
+        // TODO: TransactionService에 getTransactions 메서드를 만들고 No-offset 쿼리와 연결할 예정
+        List<TransactionResponseDto> historyList = null; // 임시 처리 (서비스 로직 연동 시 변경)
+
+        return ResponseEntity.ok(GlobalResponse.ok("거래 내역 조회 성공", historyList));
+    }
+}

--- a/src/main/java/com/intelliJ_JO/modam/domain/transaction/dto/request/TransactionRequestDto.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/transaction/dto/request/TransactionRequestDto.java
@@ -1,0 +1,31 @@
+package com.intelliJ_JO.modam.domain.transaction.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TransactionRequestDto {
+
+    @NotNull(message = "계좌 ID는 필수입니다.")
+    private Long accountId;         // 어떤 계좌에서 일어난 거래인지
+
+    @NotNull(message = "사용자 ID는 필수입니다.")
+    private Long memberId;          // 누가 거래를 일으켰는지
+
+    private Long cardId;            // ✨ 추가: 어떤 카드로 결제했는지 (입출금 시에는 null)
+
+    @NotBlank(message = "거래 유형(DEPOSIT/WITHDRAW/PAYMENT)은 필수입니다.")
+    private String transactionType; // "DEPOSIT"(입금), "WITHDRAW"(출금), "PAYMENT"(결제)
+
+    @NotNull(message = "거래 금액은 필수입니다.")
+    private Long amount;            // 얼마인지
+
+    private String merchantName;    // 가맹점 이름 (결제일 경우에만 사용, 입출금은 null)
+
+    private String category;        // 카테고리 (식비, 교통비 등)
+}

--- a/src/main/java/com/intelliJ_JO/modam/domain/transaction/dto/response/TransactionResponseDto.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/transaction/dto/response/TransactionResponseDto.java
@@ -1,0 +1,28 @@
+package com.intelliJ_JO.modam.domain.transaction.dto.response;
+
+import com.intelliJ_JO.modam.domain.transaction.entity.Transaction;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class TransactionResponseDto {
+    private Long transactionId;
+    private String transactionType; // DEPOSIT, WITHDRAW, PAYMENT
+    private Long amount;
+    private Long afterBalance;
+    private String merchantName;
+    private String category;
+    private LocalDateTime createdAt;
+
+    // Entity를 DTO로 변환하는 생성자
+    public TransactionResponseDto(Transaction transaction) {
+        this.transactionId = transaction.getId();
+        this.transactionType = transaction.getTransactionType();
+        this.amount = transaction.getAmount();
+        this.afterBalance = transaction.getAfterBalance();
+        this.merchantName = transaction.getMerchantName();
+        this.category = transaction.getCategory();
+        this.createdAt = transaction.getCreatedAt();
+    }
+}

--- a/src/main/java/com/intelliJ_JO/modam/domain/transaction/entity/Transaction.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/transaction/entity/Transaction.java
@@ -1,0 +1,52 @@
+package com.intelliJ_JO.modam.domain.transaction.entity;
+
+import com.intelliJ_JO.modam.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "transaction")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE) // ✨ Builder를 쓰기 위한 짝꿍
+@Builder // ✨ 서비스 클래스에서 객체를 쉽게 만들게 해줌
+public class Transaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "acc_id", nullable = false)
+    private Account account;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "card_id") // 카드 결제가 아닌 송금일 수 있으므로 nullable
+    private Card card;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mem_id", nullable = false)
+    private Member member;
+
+    @Column(name = "tx_type", nullable = false, length = 20)
+    private String transactionType; // DEPOSIT, WITHDRAW, PAYMENT
+
+    @Column(length = 50)
+    private String category;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Column(name = "aft_bal", nullable = false)
+    private Long afterBalance;
+
+    @Column(name = "merch_nm", length = 100)
+    private String merchantName;
+
+    @CreationTimestamp // ✨ INSERT 될 때 자동으로 현재 시간 세팅
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/intelliJ_JO/modam/domain/transaction/repository/TransactionRepository.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/transaction/repository/TransactionRepository.java
@@ -1,0 +1,19 @@
+package com.intelliJ_JO.modam.domain.transaction.repository;
+
+import com.intelliJ_JO.modam.domain.transaction.entity.Transaction;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TransactionRepository extends JpaRepository<Transaction, Long> {
+
+    // 💡 [무한 스크롤용 1] 처음 화면 진입 시 (가장 최근 내역 10개 호출)
+    List<Transaction> findByAccountIdOrderByCreatedAtDesc(Long accountId, Pageable pageable);
+
+    // 💡 [무한 스크롤용 2] 스크롤을 내렸을 때 (마지막으로 본 ID보다 더 옛날 데이터 10개 호출)
+    // "이 계좌의 거래 내역 중, 방금 본 마지막 거래ID(lastTransactionId)보다 작은(이전) 것들을 최신순으로 가져와!"
+    List<Transaction> findByAccountIdAndIdLessThanOrderByCreatedAtDesc(Long accountId, Long lastTransactionId, Pageable pageable);
+}

--- a/src/main/java/com/intelliJ_JO/modam/domain/transaction/service/TransactionService.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/transaction/service/TransactionService.java
@@ -1,0 +1,47 @@
+package com.intelliJ_JO.modam.domain.transaction.service;
+
+import com.intelliJ_JO.modam.domain.transaction.dto.request.TransactionRequestDto;
+import com.intelliJ_JO.modam.domain.transaction.repository.TransactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TransactionService {
+
+    private final TransactionRepository transactionRepository;
+    // private final AccountRepository accountRepository; // 조장님이 만드시면 주석 해제!
+    // private final MemberRepository memberRepository;
+
+    @Transactional
+    public void createTransaction(TransactionRequestDto requestDto) {
+
+        /*
+         * 🚨 [TODO] 조장님이 Account, Member 엔티티를 완성하면 아래 주석을 풀고 연동합니다!
+         *
+         * 1. DB에서 계좌와 멤버 객체를 꺼내옵니다.
+         * Account account = accountRepository.findById(requestDto.getAccountId())
+         *         .orElseThrow(() -> new IllegalArgumentException("계좌를 찾을 수 없습니다."));
+         * Member member = memberRepository.findById(requestDto.getMemberId())
+         *         .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+         *
+         * 2. 거래 유형(입금/출금/결제)에 따라 계좌 잔액(account.balance)을 더하거나 뺍니다.
+         *    (출금이나 결제일 경우 잔액이 부족하면 예외를 발생시키는 로직 필수!)
+         *
+         * 3. 계산된 최종 잔액(afterBalance)을 포함하여 Transaction 엔티티를 조립합니다.
+         * Transaction transaction = Transaction.builder()
+         *         .account(account)
+         *         .member(member)
+         *         .transactionType(requestDto.getTransactionType())
+         *         .amount(requestDto.getAmount())
+         *         .afterBalance(계산된_최종_잔액) // 중요!
+         *         .merchantName(requestDto.getMerchantName())
+         *         .category(requestDto.getCategory())
+         *         .build();
+         *
+         * 4. 내역을 DB에 저장합니다.
+         * transactionRepository.save(transaction);
+         */
+    }
+}

--- a/src/main/java/com/intelliJ_JO/modam/global/response/Test.java
+++ b/src/main/java/com/intelliJ_JO/modam/global/response/Test.java
@@ -1,0 +1,4 @@
+package com.intelliJ_JO.modam.global.response;
+
+public class Test {
+}


### PR DESCRIPTION
## 연관된 이슈 번호
 - Closes : #12 
## 🎯 작업 요약
모담(MODAM) 프로젝트의 핵심인 `Transaction` (금액 사용) 도메인의 기초 뼈대와 API 엔드포인트를 구현했습니다.

## ✅ 상세 작업 내용
1. **Transaction 엔티티 설계**
   - 확장성을 고려하여 금액 관련 필드(`amount`, `afterBalance`)를 `Long` 타입으로 적용
   - `Account`, `Member`, `Card`와의 `@ManyToOne(FetchType.LAZY)` 연관관계 매핑 완료
2. **무한 스크롤 (No-Offset) 기반 Repository 세팅**
   - 기존 Offset 방식의 데이터 중복 문제를 방지하기 위해 Cursor 기반(마지막 ID 기준) 조회 쿼리 작성
3. **DTO 및 유효성 검사 적용**
   - 프론트엔드 요청을 받을 `TransactionRequestDto`에 `@NotNull` 등 검증 로직 추가
   - 응답 시 필요한 데이터만 전달하는 `TransactionResponseDto` 작성
4. **Controller & Service 뼈대 구현**
   - 조장님이 작성해주신 `GlobalResponse` 포맷을 적용하여 API 응답 통일화

## 📢 프론트엔드 팀원분들께 (API 사용법)
- **거래 내역 조회 시 무한 스크롤이 적용되어 있습니다!**
- 처음 목록을 부를 때는 그냥 호출하시고, 스크롤을 내려서 다음 데이터를 부를 때는 `?lastTransactionId=마지막으로본거래ID` 파라미터를 함께 넘겨주세요!

## 🚨 백엔드 팀(조장님) 확인 요청
- `TransactionService` 내의 실제 입출금 잔액 증감 로직은 `Account` 및 `Member` 엔티티가 `main`에 머지된 후 연동하기 위해 **주석 처리(TODO)** 해두었습니다. 해당 엔티티들이 올라오면 바로 주석 해제 후 기능 완성하겠습니다!

