### PR TITLE
feat : 계좌 개설 POST 연동 및 AccountViewController 분리

### DIFF
--- a/src/main/java/com/intelliJ_JO/modam/global/view/AccountViewController.java
+++ b/src/main/java/com/intelliJ_JO/modam/global/view/AccountViewController.java
@@ -1,0 +1,64 @@
+package com.intelliJ_JO.modam.global.view;
+
+import com.intelliJ_JO.modam.domain.account.dto.AccountCreateRequestDto;
+import com.intelliJ_JO.modam.domain.account.dto.AccountResponseDto;
+import com.intelliJ_JO.modam.domain.account.entity.AccountType;
+import com.intelliJ_JO.modam.domain.account.service.AccountService;
+import com.intelliJ_JO.modam.config.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequiredArgsConstructor
+public class AccountViewController {
+
+    private final AccountService accountService;
+
+    // 1. 계좌 개설 화면 열기 (AuthViewController에서 가져옴)
+    @GetMapping("/account-setup")
+    public String accountSetup() {
+        return "domain/auth/account-setup";
+    }
+
+    // 2. 계좌 개설 폼 제출 (원석님이 새로 작성할 POST 핵심 로직!)
+    @PostMapping("/account-setup")
+    public String processAccountSetup(
+            @RequestParam String accountPassword,
+            @RequestParam String accountPasswordConfirm,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            RedirectAttributes redirectAttributes) {
+
+        // DTO 조립 (html 폼에서 넘어온 데이터 세팅)
+        AccountCreateRequestDto request = new AccountCreateRequestDto();
+        request.setPassword(accountPassword);
+        request.setPasswordConfirm(accountPasswordConfirm);
+        request.setAccountType(AccountType.GROUP); // 모임 통장이므로 GROUP 타입 설정
+
+        // 서비스 호출하여 계좌 생성 및 개설자를 AccountMember로 등록
+        AccountResponseDto savedAccount = accountService.createAccount(request, userDetails.getMember());
+
+        // 생성된 계좌번호를 다음 완료 화면으로 1회성으로 전달 (Flash Attribute)
+        redirectAttributes.addFlashAttribute("accountNumber", savedAccount.getAccountNumber());
+
+        return "redirect:/account-setup-complete";
+    }
+
+    // 3. 계좌 개설 완료 화면 (AuthViewController에서 가져옴)
+    @GetMapping("/account-setup-complete")
+    public String accountSetupComplete(Model model) {
+        // RedirectAttributes로 넘어온 accountNumber는 Thymeleaf에서 바로 사용 가능
+        return "domain/auth/account-setup-complete";
+    }
+
+    // (선택) /account-setup-complete 화면 하단의 "모담 시작하기" POST 핸들러
+    @PostMapping("/account-setup-complete")
+    public String startModam() {
+        return "redirect:/dashboard"; // 대시보드로 이동
+    }
+}

--- a/src/main/java/com/intelliJ_JO/modam/global/view/AuthViewController.java
+++ b/src/main/java/com/intelliJ_JO/modam/global/view/AuthViewController.java
@@ -155,14 +155,4 @@ public class AuthViewController {
     public String terms() {
         return "domain/auth/terms";
     }
-
-    @GetMapping("/account-setup")
-    public String accountSetup() {
-        return "domain/auth/account-setup";
-    }
-
-    @GetMapping("/account-setup-complete")
-    public String accountSetupComplete() {
-        return "domain/auth/account-setup-complete";
-    }
 }


### PR DESCRIPTION
## 📌 작업 내용 (What)
- 회원가입 이후 진행되는 온보딩의 핵심, **모임 통장(계좌) 개설 로직 연동**을 완료했습니다.
- 도메인 분리 원칙에 따라 `AuthViewController`에 있던 계좌 관련 GET 매핑을 `AccountViewController`로 분리하여 응집도를 높였습니다.
- 사용자가 입력한 비밀번호를 바탕으로 `AccountService.createAccount()`를 호출하여 실제 DB에 계좌가 적재되도록 POST 핸들러를 구현했습니다.

 - Closes : #73 

## 💡 주요 구현 포인트
- **POST-Redirect-GET 패턴 적용:** 계좌 생성 후 새로고침 시 폼이 재제출되는 것을 막기 위해 `redirect:/account-setup-complete`로 넘겼습니다.
- **Flash Attribute 활용:** 생성된 계좌번호(`accountNumber`)를 뷰에 한 번만 노출하기 위해 보안상 안전한 `addFlashAttribute`를 사용했습니다.

## 🛠️ 향후 계획 (Next Steps)
- 본 PR 머지 후, 로그인 시 계좌 보유 여부를 파악하여 대시보드 진입을 제어하는 방어 로직(리다이렉트) 이슈를 이어서 진행할 예정입니다.