### PR TITLE
회원가입할 때 주소 검색 api 추가

### DIFF
--- a/src/main/java/com/intelliJ_JO/modam/domain/item/init/ItemDataInitializer.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/item/init/ItemDataInitializer.java
@@ -1,0 +1,42 @@
+package com.intelliJ_JO.modam.domain.item.init;
+
+import com.intelliJ_JO.modam.domain.item.entity.ItemEntity;
+import com.intelliJ_JO.modam.domain.item.enums.ItemStatus;
+import com.intelliJ_JO.modam.domain.item.repository.ItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ItemDataInitializer implements CommandLineRunner {
+
+    private final ItemRepository itemRepository;
+
+    @Override
+    public void run(String... args) {
+        if (itemRepository.count() > 0) return;
+
+        itemRepository.saveAll(List.of(
+                item("봄 테마",      "theme",    500,  null),
+                item("여름 테마",    "theme",    600,  null),
+                item("가을 테마",    "theme",    700,  null),
+                item("겨울 테마",    "theme",    800,  null),
+                item("귀여운 이모티콘", "emoticon", 300, null),
+                item("사랑 이모티콘",  "emoticon", 400, null),
+                item("웃음 이모티콘",  "emoticon", 350, null)
+        ));
+    }
+
+    private ItemEntity item(String name, String type, int price, String imgUrl) {
+        return ItemEntity.builder()
+                .itemName(name)
+                .itemType(type)
+                .price(price)
+                .imgUrl(imgUrl)
+                .isActive(ItemStatus.ACTIVE)
+                .build();
+    }
+}

--- a/src/main/java/com/intelliJ_JO/modam/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/item/repository/ItemRepository.java
@@ -1,0 +1,18 @@
+package com.intelliJ_JO.modam.domain.item.repository;
+
+import com.intelliJ_JO.modam.domain.item.entity.ItemEntity;
+import com.intelliJ_JO.modam.domain.item.enums.ItemStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface ItemRepository extends JpaRepository<ItemEntity, Long> {
+
+    @Query("SELECT DISTINCT i.itemType FROM ItemEntity i WHERE i.isActive = :status")
+    List<String> findDistinctItemTypeByIsActive(ItemStatus status);
+
+    List<ItemEntity> findByIsActive(ItemStatus status);
+
+    List<ItemEntity> findByItemTypeAndIsActive(String itemType, ItemStatus status);
+}

--- a/src/main/java/com/intelliJ_JO/modam/domain/item/service/ItemService.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/item/service/ItemService.java
@@ -1,0 +1,40 @@
+package com.intelliJ_JO.modam.domain.item.service;
+
+import com.intelliJ_JO.modam.domain.item.entity.ItemEntity;
+import com.intelliJ_JO.modam.domain.item.enums.ItemStatus;
+import com.intelliJ_JO.modam.domain.item.repository.ItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class ItemService {
+
+    private final ItemRepository itemRepository;
+
+    // DB의 itemType 값 → 화면에 표시할 한글 라벨
+    private static final Map<String, String> CATEGORY_LABELS = Map.of(
+            "theme",    "테마",
+            "emoticon", "이모티콘"
+    );
+
+    public List<Map<String, String>> getCategories() {
+        return itemRepository.findDistinctItemTypeByIsActive(ItemStatus.ACTIVE)
+                .stream()
+                .map(type -> Map.of(
+                        "value", type,
+                        "label", CATEGORY_LABELS.getOrDefault(type, type)
+                ))
+                .toList();
+    }
+
+    public List<ItemEntity> getItems(String category) {
+        if (category == null || category.isBlank()) {
+            return itemRepository.findByIsActive(ItemStatus.ACTIVE);
+        }
+        return itemRepository.findByItemTypeAndIsActive(category, ItemStatus.ACTIVE);
+    }
+}

--- a/src/main/java/com/intelliJ_JO/modam/global/view/ShopViewController.java
+++ b/src/main/java/com/intelliJ_JO/modam/global/view/ShopViewController.java
@@ -1,14 +1,70 @@
 package com.intelliJ_JO.modam.global.view;
 
+import com.intelliJ_JO.modam.domain.item.entity.ItemEntity;
+import com.intelliJ_JO.modam.domain.item.service.ItemService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Controller
+@RequiredArgsConstructor
 public class ShopViewController {
 
+    private final ItemService itemService;
+
+    private static final int PAGE_SIZE = 8;
+
     @GetMapping("/point-shop")
-    public String pointShop() {
+    public String pointShop(
+            @RequestParam(required = false) String category,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(required = false, defaultValue = "products") String tab,
+            @RequestParam(defaultValue = "1") int historyPage,
+            Model model
+    ) {
+        // 카테고리 목록 (DB의 distinct itemType → 한글 라벨)
+        model.addAttribute("categories", itemService.getCategories());
+        model.addAttribute("selectedCategory", category);
+
+        // 상품 목록 + 페이지네이션
+        List<ItemEntity> allItems = itemService.getItems(category);
+        int totalPages = Math.max(1, (int) Math.ceil((double) allItems.size() / PAGE_SIZE));
+        int currentPage = Math.max(1, Math.min(page, totalPages));
+
+        int from = (currentPage - 1) * PAGE_SIZE;
+        int to   = Math.min(from + PAGE_SIZE, allItems.size());
+
+        List<Map<String, Object>> products = allItems.subList(from, to).stream()
+                .map(item -> {
+                    Map<String, Object> m = new HashMap<>();
+                    m.put("id",        item.getId());
+                    m.put("name",      item.getItemName());
+                    m.put("pointCost", item.getPrice());
+                    m.put("imageUrl",  item.getImgUrl());
+                    m.put("image",     "🎁");
+                    return m;
+                })
+                .toList();
+
+        model.addAttribute("products",    products);
+        model.addAttribute("currentPage", currentPage);
+        model.addAttribute("totalPages",  totalPages);
+
+        // 포인트 잔액 (추후 인증 연동 시 실제 값으로 교체)
+        model.addAttribute("couplePoints", 0);
+
+        // 내역 탭 — 추후 인증 연동
+        model.addAttribute("paginatedHistory",  List.of());
+        model.addAttribute("historyPage",       1);
+        model.addAttribute("historyTotalPages", 1);
+
         return "domain/shop/point-shop";
     }
 

--- a/src/main/resources/templates/domain/auth/signup.html
+++ b/src/main/resources/templates/domain/auth/signup.html
@@ -6,6 +6,7 @@
   <title>회원가입 - 모담</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/lucide@latest"></script>
+  <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
 </head>
 <body class="min-h-screen bg-[#FAFAFA] relative">
 
@@ -309,9 +310,13 @@
     }
 
     function searchAddress() {
-      // 카카오 우편번호 API 연동 예시
-      // new daum.Postcode({ oncomplete: function(data) { ... } }).open();
-      alert('주소 검색 API를 연동해주세요 (카카오 Postcode API)');
+      new daum.Postcode({
+        oncomplete: function(data) {
+          document.getElementById('postalCode').value = data.zonecode;
+          document.getElementById('address').value = data.roadAddress || data.jibunAddress;
+          document.getElementById('addressDetail').focus();
+        }
+      }).open();
     }
   </script>
 </body>

--- a/src/main/resources/templates/domain/shop/point-shop.html
+++ b/src/main/resources/templates/domain/shop/point-shop.html
@@ -12,64 +12,195 @@
 
   <main class="flex-1 w-full max-w-[1440px] mx-auto bg-gray-50">
     <div class="px-8 py-12">
+      <!-- 헤더 -->
+      <div class="mb-12">
+        <h1 class="text-4xl font-bold text-gray-900 mb-3">포인트 상점</h1>
+        <p class="text-gray-600 text-lg">모은 포인트로 다양한 상품을 구매하세요</p>
+      </div>
+
       <!-- 포인트 현황 배너 -->
-      <div class="bg-gradient-to-r from-[#FCE8E3] to-[#FFE4E8] rounded-3xl p-8 mb-10">
+      <div class="bg-gradient-to-r from-[#FCE8E3] to-[#FFE4E8] rounded-3xl border border-gray-100 shadow-sm p-8 mb-8">
         <div class="flex items-center justify-between">
-          <div>
-            <h1 class="text-4xl font-bold text-gray-900 mb-2">포인트샵</h1>
-            <p class="text-gray-600">모은 포인트로 다양한 상품을 구매해보세요</p>
+          <div class="flex items-center gap-4">
+            <div class="w-16 h-16 bg-white rounded-full flex items-center justify-center">
+              <i data-lucide="gift" class="w-8 h-8 text-[#F5A5A5]"></i>
+            </div>
+            <div>
+              <p class="text-gray-600 mb-1">내 포인트</p>
+              <p class="text-4xl text-gray-800"><span th:text="${#numbers.formatInteger(couplePoints, 0, 'COMMA')}">0</span>P</p>
+            </div>
           </div>
-          <div class="text-right">
-            <p class="text-sm text-gray-600 mb-1">보유 포인트</p>
-            <p class="text-5xl font-bold text-[#F5A5A5]"><span th:text="${#numbers.formatInteger(couplePoints, 0, 'COMMA')}">0</span>P</p>
-          </div>
+          <a th:href="@{/savings}" class="px-6 py-3 bg-white text-gray-800 rounded-2xl hover:bg-gray-50 transition-colors">
+            포인트 적립하기
+          </a>
         </div>
       </div>
 
+      <!-- 메인 탭 (상품 / 내역) -->
+      <div class="flex gap-4 mb-8">
+        <button id="tab-products"
+                onclick="switchTab('products')"
+                class="px-8 py-4 rounded-2xl transition-all font-medium bg-white text-gray-900 shadow-md border-2 border-[#F5A5A5]">
+          상품
+        </button>
+        <button id="tab-history"
+                onclick="switchTab('history')"
+                class="px-8 py-4 rounded-2xl transition-all font-medium bg-white text-gray-600 border-2 border-gray-200">
+          내역
+        </button>
+      </div>
+
+      <!-- 상품 탭 콘텐츠 -->
+      <div id="panel-products">
+
       <!-- 카테고리 필터 -->
-      <div class="flex gap-3 mb-8 flex-wrap">
+      <!-- categories: List<Map> — 각 항목은 {value: "theme", label: "테마"} 형태로 백엔드에서 전달 -->
+      <div class="flex gap-4 mb-8 flex-wrap">
         <a th:href="@{/point-shop}"
-           th:classappend="${selectedCategory == null} ? 'bg-[#F5A5A5] text-white' : 'bg-white text-gray-700 hover:border-[#F5A5A5]'"
-           class="px-5 py-2.5 rounded-full border-2 border-gray-200 transition-colors font-medium">전체</a>
+           th:classappend="${selectedCategory == null} ? 'bg-[#F5A5A5] text-white shadow-md' : 'bg-white text-gray-600 hover:bg-gray-50'"
+           class="px-6 py-3 rounded-2xl transition-colors">전체</a>
         <a th:each="cat : ${categories}"
-           th:href="@{/point-shop(category=${cat})}"
-           th:text="${cat}"
-           th:classappend="${selectedCategory == cat} ? 'bg-[#F5A5A5] text-white' : 'bg-white text-gray-700 hover:border-[#F5A5A5]'"
-           class="px-5 py-2.5 rounded-full border-2 border-gray-200 transition-colors font-medium">카테고리</a>
+           th:href="@{/point-shop(category=${cat.value})}"
+           th:text="${cat.label}"
+           th:classappend="${selectedCategory == cat.value} ? 'bg-[#F5A5A5] text-white shadow-md' : 'bg-white text-gray-600 hover:bg-gray-50'"
+           class="px-6 py-3 rounded-2xl transition-colors">카테고리</a>
       </div>
 
       <!-- 상품 그리드 -->
       <div class="grid grid-cols-4 gap-6">
-        <div th:each="product : ${products}" class="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden hover:shadow-md hover:border-[#FCE8E3] transition-all">
-          <a th:href="@{/point-shop/product/{id}(id=${product.id})}">
-            <div class="aspect-square bg-gray-50 flex items-center justify-center overflow-hidden">
-              <img th:if="${product.imageUrl}" th:src="${product.imageUrl}" th:alt="${product.name}" class="w-full h-full object-cover"/>
-              <i th:unless="${product.imageUrl}" data-lucide="gift" class="w-16 h-16 text-gray-300"></i>
-            </div>
-            <div class="p-5">
-              <span class="text-xs text-[#F5A5A5] font-medium bg-[#FCE8E3] px-2 py-1 rounded-full" th:text="${product.category}">카테고리</span>
-              <h3 class="text-gray-900 font-semibold mt-2 mb-1" th:text="${product.name}">상품명</h3>
-              <p class="text-sm text-gray-500 mb-3" th:text="${product.description}">설명</p>
-              <div class="flex items-center justify-between">
-                <span class="text-lg font-bold text-[#F5A5A5]"><span th:text="${#numbers.formatInteger(product.pointCost, 0, 'COMMA')}">0</span>P</span>
-                <span th:if="${couplePoints >= product.pointCost}"
-                      class="text-xs text-green-600 bg-green-50 px-2 py-1 rounded-full">구매 가능</span>
-                <span th:unless="${couplePoints >= product.pointCost}"
-                      class="text-xs text-gray-400 bg-gray-50 px-2 py-1 rounded-full">포인트 부족</span>
-              </div>
-            </div>
-          </a>
-        </div>
+        <a th:each="product : ${products}"
+           th:href="@{/point-shop/product/{id}(id=${product.id})}"
+           class="bg-white rounded-3xl shadow-sm hover:shadow-md transition-all overflow-hidden group">
+          <div class="aspect-square bg-gradient-to-br from-[#FCE8E3] to-[#FFE4E8] flex items-center justify-center overflow-hidden">
+            <img th:if="${product.imageUrl}" th:src="${product.imageUrl}" th:alt="${product.name}"
+                 class="w-full h-full object-cover group-hover:scale-110 transition-transform"/>
+            <span th:unless="${product.imageUrl}" class="text-8xl group-hover:scale-110 transition-transform inline-block"
+                  th:text="${product.image}">🎁</span>
+          </div>
+          <div class="p-5">
+            <h3 class="text-lg text-gray-800 mb-2" th:text="${product.name}">상품명</h3>
+            <p class="text-2xl text-[#F5A5A5]"><span th:text="${#numbers.formatInteger(product.pointCost, 0, 'COMMA')}">0</span>P</p>
+          </div>
+        </a>
       </div>
 
       <div th:if="${#lists.isEmpty(products)}" class="text-center py-20">
         <i data-lucide="gift" class="w-16 h-16 text-gray-300 mx-auto mb-4"></i>
         <p class="text-xl text-gray-500">상품이 없습니다</p>
       </div>
+
+      <!-- 상품 페이지네이션 -->
+      <div th:if="${totalPages > 1}" class="flex justify-center items-center gap-2 mt-8">
+        <a th:if="${currentPage > 1}"
+           th:href="@{/point-shop(category=${selectedCategory}, page=${currentPage - 1})}"
+           class="w-10 h-10 flex items-center justify-center rounded-full bg-white border border-gray-200 hover:border-[#F5A5A5] text-gray-600 transition-colors">
+          <i data-lucide="chevron-left" class="w-4 h-4"></i>
+        </a>
+        <th:block th:each="i : ${#numbers.sequence(1, totalPages)}">
+          <a th:href="@{/point-shop(category=${selectedCategory}, page=${i})}"
+             th:text="${i}"
+             th:classappend="${i == currentPage} ? 'bg-[#F5A5A5] text-white border-[#F5A5A5]' : 'bg-white text-gray-600 hover:border-[#F5A5A5]'"
+             class="w-10 h-10 flex items-center justify-center rounded-full border border-gray-200 transition-colors">1</a>
+        </th:block>
+        <a th:if="${currentPage < totalPages}"
+           th:href="@{/point-shop(category=${selectedCategory}, page=${currentPage + 1})}"
+           class="w-10 h-10 flex items-center justify-center rounded-full bg-white border border-gray-200 hover:border-[#F5A5A5] text-gray-600 transition-colors">
+          <i data-lucide="chevron-right" class="w-4 h-4"></i>
+        </a>
+      </div>
+
+      </div><!-- end panel-products -->
+
+      <!-- 내역 탭 콘텐츠 -->
+      <div id="panel-history" style="display:none">
+        <div class="bg-white rounded-3xl shadow-sm border border-gray-100 p-8 mb-8">
+          <h2 class="text-2xl font-bold text-gray-900 mb-8">포인트 적립/사용 내역</h2>
+
+          <div class="space-y-3">
+            <div th:each="item : ${paginatedHistory}"
+                 th:classappend="${item.isSpecial and item.isNew} ? 'bg-gradient-to-r from-[#FFF0F3] to-[#FFE4E8] border border-[#F5A5A5]/20 hover:from-[#FFE4E8] hover:to-[#FFD5DC]' : (${item.isNew} ? 'bg-blue-50 hover:bg-blue-100 border border-blue-100' : 'hover:bg-gray-50')"
+                 class="flex items-center justify-between p-5 rounded-2xl transition-colors">
+              <div class="flex items-center gap-4">
+                <div th:classappend="${item.isSpecial} ? 'bg-gradient-to-br from-[#F5A5A5] to-[#F28B8B]' : (${item.type == 'EARN'} ? 'bg-green-50' : 'bg-red-50')"
+                     class="w-12 h-12 rounded-xl flex items-center justify-center">
+                  <i th:if="${item.isSpecial}" data-lucide="gift" class="w-6 h-6 text-white"></i>
+                  <i th:if="${!item.isSpecial and item.type == 'EARN'}" data-lucide="plus" class="w-6 h-6 text-green-500"></i>
+                  <i th:if="${!item.isSpecial and item.type == 'USE'}" data-lucide="minus" class="w-6 h-6 text-red-500"></i>
+                </div>
+                <div>
+                  <div class="flex items-center gap-2 mb-1">
+                    <p th:classappend="${item.isSpecial} ? 'text-[#F28B8B]' : 'text-gray-900'"
+                       th:text="${item.descrip}" class="font-medium">설명</p>
+                    <span th:if="${item.isNew}"
+                          class="px-2 py-0.5 bg-[#F5A5A5] text-white text-xs rounded-full font-semibold">NEW</span>
+                  </div>
+                  <div class="flex items-center gap-2 text-sm text-gray-500">
+                    <i data-lucide="clock" class="w-4 h-4"></i>
+                    <span th:text="${item.createdAt}">날짜</span>
+                  </div>
+                </div>
+              </div>
+              <div class="text-right">
+                <p th:classappend="${item.isSpecial} ? 'text-[#F5A5A5]' : (${item.type == 'EARN'} ? 'text-green-600' : 'text-red-600')"
+                   class="text-xl font-bold mb-1">
+                  <span th:text="${item.type == 'EARN'} ? '+' : '-'">+</span><span th:text="${#numbers.formatInteger(item.amt, 0, 'COMMA')}">0</span>P
+                </p>
+                <p class="text-sm text-gray-500">잔액 <span th:text="${#numbers.formatInteger(item.aftBal, 0, 'COMMA')}">0</span>P</p>
+              </div>
+            </div>
+          </div>
+
+          <div th:if="${#lists.isEmpty(paginatedHistory)}" class="text-center py-16">
+            <i data-lucide="clock" class="w-12 h-12 text-gray-300 mx-auto mb-4"></i>
+            <p class="text-gray-500">포인트 내역이 없습니다</p>
+          </div>
+        </div>
+
+        <!-- 내역 페이지네이션 -->
+        <div th:if="${historyTotalPages > 1}" class="flex justify-center items-center gap-2">
+          <a th:if="${historyPage > 1}"
+             th:href="@{/point-shop(tab='history', historyPage=${historyPage - 1})}"
+             class="w-10 h-10 flex items-center justify-center rounded-full bg-white border border-gray-200 hover:border-[#F5A5A5] text-gray-600 transition-colors">
+            <i data-lucide="chevron-left" class="w-4 h-4"></i>
+          </a>
+          <th:block th:each="i : ${#numbers.sequence(1, historyTotalPages)}">
+            <a th:href="@{/point-shop(tab='history', historyPage=${i})}"
+               th:text="${i}"
+               th:classappend="${i == historyPage} ? 'bg-[#F5A5A5] text-white border-[#F5A5A5]' : 'bg-white text-gray-600 hover:border-[#F5A5A5]'"
+               class="w-10 h-10 flex items-center justify-center rounded-full border border-gray-200 transition-colors">1</a>
+          </th:block>
+          <a th:if="${historyPage < historyTotalPages}"
+             th:href="@{/point-shop(tab='history', historyPage=${historyPage + 1})}"
+             class="w-10 h-10 flex items-center justify-center rounded-full bg-white border border-gray-200 hover:border-[#F5A5A5] text-gray-600 transition-colors">
+            <i data-lucide="chevron-right" class="w-4 h-4"></i>
+          </a>
+        </div>
+      </div><!-- end panel-history -->
+
     </div>
   </main>
 
   <div th:replace="~{common/layout/footer :: footer}"></div>
-  <script>lucide.createIcons();</script>
+  <script>
+    lucide.createIcons();
+
+    const TAB_ACTIVE   = 'px-8 py-4 rounded-2xl transition-all font-medium bg-white text-gray-900 shadow-md border-2 border-[#F5A5A5]';
+    const TAB_INACTIVE = 'px-8 py-4 rounded-2xl transition-all font-medium bg-white text-gray-600 border-2 border-gray-200';
+
+    function switchTab(tab) {
+      const showProducts = tab === 'products';
+      document.getElementById('panel-products').style.display = showProducts ? '' : 'none';
+      document.getElementById('panel-history').style.display  = showProducts ? 'none' : '';
+
+      document.getElementById('tab-products').className = showProducts ? TAB_ACTIVE : TAB_INACTIVE;
+      document.getElementById('tab-history').className  = showProducts ? TAB_INACTIVE : TAB_ACTIVE;
+    }
+
+    // URL에 tab=history 파라미터가 있으면 내역 탭으로 초기화
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('tab') === 'history') {
+      switchTab('history');
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
주소 검색 API 기능 요약
커밋 a94a49f — 2026-05-20
변경 파일: [signup.html](vscode-webview://02vbm8q1ugsbpq5su2l5pap41biev5vtiohlkuj90095nbt15e5e/src/main/resources/templates/domain/auth/signup.html)

변경 내용
Before — 미구현 상태로 alert만 표시


function searchAddress() {
  // 카카오 우편번호 API 연동 예시
  alert('주소 검색 API를 연동해주세요 (카카오 Postcode API)');
}
After — 카카오 Postcode API 실제 연동


// <head>에 스크립트 추가
<script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>

function searchAddress() {
  new daum.Postcode({
    oncomplete: function(data) {
      document.getElementById('postalCode').value = data.zonecode;
      document.getElementById('address').value = data.roadAddress || data.jibunAddress;
      document.getElementById('addressDetail').focus();
    }
  }).open();
}
동작 방식
searchAddress() 호출 시 카카오 우편번호 팝업 오픈
사용자가 주소 선택하면 oncomplete 콜백 실행
postalCode 필드에 우편번호(data.zonecode) 자동 입력
address 필드에 도로명 주소 우선, 없으면 지번 주소 입력
상세주소(addressDetail) 필드로 포커스 이동