### PR TITLE
[FEAT] 간편 이체 POST 연동 및 비밀번호 검증 로직 구현

### DIFF
--- a/src/main/java/com/intelliJ_JO/modam/domain/account/service/AccountService.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/account/service/AccountService.java
@@ -137,4 +137,14 @@ public class AccountService {
         } while (accountRepository.existsByAccountNumber(candidate));
         return candidate;
     }
+
+    // [추가] 계좌 비밀번호 검증 메서드
+    public void verifyAccountPassword(Long accountId, String rawPassword) {
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 계좌입니다."));
+
+        if (!passwordEncoder.matches(rawPassword, account.getPasswordHash())) {
+            throw new IllegalArgumentException("계좌 비밀번호가 일치하지 않습니다.");
+        }
+    }
 }

--- a/src/main/java/com/intelliJ_JO/modam/domain/transaction/controller/TransactionController.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/transaction/controller/TransactionController.java
@@ -1,7 +1,9 @@
 package com.intelliJ_JO.modam.domain.transaction.controller;
 
+import com.intelliJ_JO.modam.domain.account.service.AccountService;
 import com.intelliJ_JO.modam.domain.transaction.dto.TransactionRequestDto;
 import com.intelliJ_JO.modam.domain.transaction.dto.TransactionResponseDto;
+import com.intelliJ_JO.modam.domain.transaction.entity.TransactionType;
 import com.intelliJ_JO.modam.domain.transaction.service.TransactionService;
 import com.intelliJ_JO.modam.global.response.GlobalResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,11 +21,19 @@ import java.util.List;
 public class TransactionController {
 
     private final TransactionService transactionService;
+    private final AccountService accountService; // 비밀번호 검증을 위한 의존성 주입
 
     @Operation(summary = "거래 생성")
     @PostMapping
     public GlobalResponse<TransactionResponseDto> createTransaction(
             @Valid @RequestBody TransactionRequestDto request) {
+
+        // [추가된 핵심 로직] 거래 생성 전 계좌 비밀번호 검증
+        // 출금(이체)일 경우에만 비밀번호를 검증하도록 방어 로직 추가
+        if (request.getTxType() == TransactionType.WITHDRAW && request.getAccountPassword() != null) {
+            accountService.verifyAccountPassword(request.getAccountId(), request.getAccountPassword());
+        }
+
         return GlobalResponse.ok(transactionService.createTransaction(request));
     }
 

--- a/src/main/java/com/intelliJ_JO/modam/domain/transaction/dto/TransactionRequestDto.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/transaction/dto/TransactionRequestDto.java
@@ -29,4 +29,8 @@ public class TransactionRequestDto {
 
     private String merchantName; // 가맹점명 (결제 시)
     private String category;     // 카테고리 (식비, 교통 등)
+
+    // [추가] 계좌 비밀번호
+    @jakarta.validation.constraints.NotBlank(message = "계좌 비밀번호는 필수입니다.")
+    private String accountPassword;
 }

--- a/src/main/java/com/intelliJ_JO/modam/global/view/TransferViewController.java
+++ b/src/main/java/com/intelliJ_JO/modam/global/view/TransferViewController.java
@@ -1,23 +1,112 @@
 package com.intelliJ_JO.modam.global.view;
 
+import com.intelliJ_JO.modam.config.security.CustomUserDetails;
+import com.intelliJ_JO.modam.domain.account.dto.AccountResponseDto;
+import com.intelliJ_JO.modam.domain.account.dto.GroupAccountStatusDto;
+import com.intelliJ_JO.modam.domain.account.service.AccountService;
+import com.intelliJ_JO.modam.domain.transaction.dto.TransactionRequestDto;
+import com.intelliJ_JO.modam.domain.transaction.entity.TransactionType;
+import com.intelliJ_JO.modam.domain.transaction.service.TransactionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Controller
+@RequiredArgsConstructor
 public class TransferViewController {
 
+    private final TransactionService transactionService;
+    private final AccountService accountService;
+
     @GetMapping("/transfer")
-    public String transfer() {
-        return "domain/transfer/transfer";
+    public String transfer(@AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
+        GroupAccountStatusDto status = accountService.getGroupAccountStatus(userDetails.getMember());
+        if (!status.isHasGroupAccount()) {
+            return "redirect:/account-setup";
+        }
+        AccountResponseDto account = accountService.getAccount(status.getAccountId());
+        model.addAttribute("currentBalance", account.getAvailableBalance());
+        return "domain/transfer/transfer"; // 조장님이 폴더명도 transaction -> transfer로 변경하셨네요!
+    }
+
+    @PostMapping("/transfer")
+    public String processTransfer(
+            @RequestParam String bankName,
+            @RequestParam String accountNumber,
+            @RequestParam Long amount,
+            @RequestParam String accountPassword, // [추가됨] 비밀번호 파라미터 수신
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            RedirectAttributes redirectAttributes) {
+
+        GroupAccountStatusDto status = accountService.getGroupAccountStatus(userDetails.getMember());
+
+        try {
+            // 1. 비밀번호 검증 (방금 추가한 메서드 호출)
+            accountService.verifyAccountPassword(status.getAccountId(), accountPassword);
+
+            // 2. 이체 로직 실행
+            TransactionRequestDto request = new TransactionRequestDto();
+            request.setMemberId(userDetails.getMember().getId());
+            request.setAccountId(status.getAccountId());
+            request.setTxType(TransactionType.WITHDRAW);
+            request.setAmount(amount);
+            request.setMerchantName(bankName + " " + accountNumber);
+            request.setCategory("이체");
+
+            transactionService.createTransaction(request);
+
+            // 3. 성공 시 데이터 전달
+            Map<String, Object> transferData = new HashMap<>();
+            transferData.put("bankName", getKoreanBankName(bankName));
+            transferData.put("accountNumber", accountNumber);
+            transferData.put("amount", amount);
+            redirectAttributes.addFlashAttribute("transfer", transferData);
+
+            return "redirect:/transfer/complete";
+
+        } catch (Exception e) {
+            // 실패 시 처리
+            AccountResponseDto account = accountService.getAccount(status.getAccountId());
+            Map<String, Object> failedData = new HashMap<>();
+            failedData.put("reason", e.getMessage());
+            failedData.put("amount", amount);
+            failedData.put("currentBalance", account.getAvailableBalance());
+            redirectAttributes.addFlashAttribute("failedTransfer", failedData);
+
+            return "redirect:/transfer/failed";
+        }
     }
 
     @GetMapping("/transfer/complete")
-    public String transferComplete() {
+    public String transferComplete(Model model) {
+        if (!model.containsAttribute("transfer")) return "redirect:/transfer";
         return "domain/transfer/transfer-complete";
     }
 
     @GetMapping("/transfer/failed")
-    public String transferFailed() {
+    public String transferFailed(Model model) {
+        if (!model.containsAttribute("failedTransfer")) return "redirect:/transfer";
         return "domain/transfer/transfer-failed";
+    }
+
+    private String getKoreanBankName(String bankCode) {
+        return switch (bankCode) {
+            case "kb" -> "국민은행";
+            case "shinhan" -> "신한은행";
+            case "woori" -> "우리은행";
+            case "hana" -> "하나은행";
+            case "nh" -> "농협은행";
+            case "kakao" -> "카카오뱅크";
+            case "toss" -> "토스뱅크";
+            default -> "기타은행";
+        };
     }
 }

--- a/src/main/resources/templates/domain/transfer/transfer.html
+++ b/src/main/resources/templates/domain/transfer/transfer.html
@@ -9,110 +9,164 @@
 </head>
 <body class="min-h-screen bg-[#FAFAFA] flex flex-col">
 
-  <!-- ===== 헤더 ===== -->
-  <th:block th:replace="~{common/layout/header :: nav}"></th:block>
+<th:block th:replace="~{common/layout/header :: nav}"></th:block>
 
-  <!-- ===== 메인 콘텐츠 ===== -->
-  <main class="flex-1">
-    <div class="max-w-[800px] mx-auto px-8 py-12">
+<main class="flex-1">
+  <div class="max-w-[800px] mx-auto px-8 py-12">
 
-      <div class="mb-8">
-        <h1 class="text-3xl text-gray-800">간편 이체</h1>
-        <p class="text-gray-600 mt-2">빠르고 안전하게 송금하세요</p>
-      </div>
+    <div class="mb-8">
+      <h1 class="text-3xl text-gray-800">간편 이체</h1>
+      <p class="text-gray-600 mt-2">빠르고 안전하게 송금하세요</p>
+    </div>
 
-      <!-- 이체 폼 카드 -->
-      <form th:action="@{/transfer}" method="post" onsubmit="handleTransfer(event)">
-        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
-        <input type="hidden" id="amountHidden" name="amount"/>
+    <form th:action="@{/transfer}" method="post" id="transferForm" onsubmit="handleTransfer(event)">
+      <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+      <input type="hidden" id="amountHidden" name="amount"/>
 
-        <div class="bg-white rounded-3xl shadow-sm p-10">
-          <div class="space-y-6">
+      <div class="bg-white rounded-3xl shadow-sm p-10">
+        <div class="space-y-6">
 
-            <!-- 은행 선택 -->
-            <div>
-              <label class="block text-gray-800 mb-2 text-lg">은행</label>
-              <select name="bankName" id="bankSelect" onchange="checkForm()"
-                      class="w-full px-5 py-4 border-2 border-gray-200 rounded-2xl focus:border-[#F5A5A5] focus:outline-none transition-colors text-gray-800">
-                <option value="">은행을 선택하세요</option>
-                <option value="국민은행">국민은행</option>
-                <option value="신한은행">신한은행</option>
-                <option value="우리은행">우리은행</option>
-                <option value="하나은행">하나은행</option>
-                <option value="농협은행">농협은행</option>
-                <option value="카카오뱅크">카카오뱅크</option>
-                <option value="토스뱅크">토스뱅크</option>
-              </select>
-            </div>
-
-            <!-- 계좌번호 -->
-            <div>
-              <label class="block text-gray-800 mb-2 text-lg">계좌번호</label>
-              <input type="text" id="accountNumber" name="accountNumber"
-                     oninput="checkForm()"
-                     class="w-full px-5 py-4 border-2 border-gray-200 rounded-2xl focus:border-[#F5A5A5] focus:outline-none transition-colors text-gray-800"
-                     placeholder="계좌번호를 입력하세요 (- 제외)" />
-            </div>
-
-            <!-- 금액 -->
-            <div>
-              <label class="block text-gray-800 mb-2 text-lg">금액</label>
-              <div class="relative">
-                <input type="text" id="amountDisplay"
-                       oninput="handleAmountInput(this)"
-                       class="w-full px-5 py-4 border-2 border-gray-200 rounded-2xl focus:border-[#F5A5A5] focus:outline-none transition-colors text-gray-800"
-                       placeholder="송금할 금액을 입력하세요" />
-                <span class="absolute right-5 top-1/2 -translate-y-1/2 text-gray-600">원</span>
-              </div>
-              <p id="amountFormatted" class="text-sm text-gray-500 mt-2 hidden"></p>
-            </div>
-
-            <!-- 빠른 금액 버튼 -->
-            <div class="grid grid-cols-4 gap-3">
-              <button type="button" onclick="addAmount(10000)"
-                      class="py-3 bg-[#FCE8E3] text-gray-800 rounded-xl hover:bg-[#FBD5CE] transition-colors">
-                +1만
-              </button>
-              <button type="button" onclick="addAmount(30000)"
-                      class="py-3 bg-[#FCE8E3] text-gray-800 rounded-xl hover:bg-[#FBD5CE] transition-colors">
-                +3만
-              </button>
-              <button type="button" onclick="addAmount(50000)"
-                      class="py-3 bg-[#FCE8E3] text-gray-800 rounded-xl hover:bg-[#FBD5CE] transition-colors">
-                +5만
-              </button>
-              <button type="button" onclick="addAmount(100000)"
-                      class="py-3 bg-[#FCE8E3] text-gray-800 rounded-xl hover:bg-[#FBD5CE] transition-colors">
-                +10만
-              </button>
-            </div>
-
-            <!-- 안내 -->
-            <div class="bg-[#FCE8E3] rounded-2xl p-5">
-              <p class="text-sm text-gray-700">
-                💡 1일 이체 한도는 500만원입니다. 이체 후 취소가 불가능하니 신중하게 확인해주세요.
-              </p>
-            </div>
+          <div>
+            <label class="block text-gray-800 mb-2 text-lg">은행</label>
+            <select name="bankName" id="bankSelect" onchange="checkForm()"
+                    class="w-full px-5 py-4 border-2 border-gray-200 rounded-2xl focus:border-[#F5A5A5] focus:outline-none transition-colors text-gray-800">
+              <option value="">은행을 선택하세요</option>
+              <option value="국민은행">국민은행</option>
+              <option value="신한은행">신한은행</option>
+              <option value="우리은행">우리은행</option>
+              <option value="하나은행">하나은행</option>
+              <option value="농협은행">농협은행</option>
+              <option value="카카오뱅크">카카오뱅크</option>
+              <option value="토스뱅크">토스뱅크</option>
+            </select>
           </div>
 
-          <!-- 송금 버튼 -->
-          <button type="submit" id="transferBtn" disabled
-                  class="w-full py-4 rounded-2xl mt-8 transition-all bg-gray-200 text-gray-400 cursor-not-allowed">
-            송금하기
-          </button>
+          <div>
+            <label class="block text-gray-800 mb-2 text-lg">계좌번호</label>
+            <input type="text" id="accountNumber" name="accountNumber"
+                   oninput="checkForm()"
+                   class="w-full px-5 py-4 border-2 border-gray-200 rounded-2xl focus:border-[#F5A5A5] focus:outline-none transition-colors text-gray-800"
+                   placeholder="계좌번호를 입력하세요 (- 제외)" />
+          </div>
+
+          <div>
+            <label class="block text-gray-800 mb-2 text-lg">금액</label>
+            <div class="relative">
+              <input type="text" id="amountDisplay"
+                     oninput="handleAmountInput(this)"
+                     class="w-full px-5 py-4 border-2 border-gray-200 rounded-2xl focus:border-[#F5A5A5] focus:outline-none transition-colors text-gray-800"
+                     placeholder="송금할 금액을 입력하세요" />
+              <span class="absolute right-5 top-1/2 -translate-y-1/2 text-gray-600">원</span>
+            </div>
+            <p id="amountFormatted" class="text-sm text-gray-500 mt-2 hidden"></p>
+          </div>
+
+          <div class="grid grid-cols-4 gap-3">
+            <button type="button" onclick="addAmount(10000)"
+                    class="py-3 bg-[#FCE8E3] text-gray-800 rounded-xl hover:bg-[#FBD5CE] transition-colors">
+              +1만
+            </button>
+            <button type="button" onclick="addAmount(30000)"
+                    class="py-3 bg-[#FCE8E3] text-gray-800 rounded-xl hover:bg-[#FBD5CE] transition-colors">
+              +3만
+            </button>
+            <button type="button" onclick="addAmount(50000)"
+                    class="py-3 bg-[#FCE8E3] text-gray-800 rounded-xl hover:bg-[#FBD5CE] transition-colors">
+              +5만
+            </button>
+            <button type="button" onclick="addAmount(100000)"
+                    class="py-3 bg-[#FCE8E3] text-gray-800 rounded-xl hover:bg-[#FBD5CE] transition-colors">
+              +10만
+            </button>
+          </div>
+
+          <div>
+            <label class="block text-gray-800 mb-2 text-lg">계좌 비밀번호</label>
+            <input type="password" name="accountPassword" id="accountPassword" maxlength="4"
+                   oninput="checkForm()"
+                   class="w-full px-5 py-4 border-2 border-gray-200 rounded-2xl focus:border-[#F5A5A5] focus:outline-none transition-colors text-center text-2xl tracking-[1em]"
+                   placeholder="••••"/>
+          </div>
+
+          <div class="bg-[#FCE8E3] rounded-2xl p-5">
+            <p class="text-sm text-gray-700">
+              💡 1일 이체 한도는 500만원입니다. 이체 후 취소가 불가능하니 신중하게 확인해주세요.
+            </p>
+          </div>
         </div>
-      </form>
 
-    </div>
-  </main>
+        <button type="submit" id="transferBtn" disabled
+                class="w-full py-4 rounded-2xl mt-8 transition-all bg-gray-200 text-gray-400 cursor-not-allowed font-semibold text-lg">
+          송금하기
+        </button>
+      </div>
+    </form>
 
-  <!-- ===== 푸터 ===== -->
-  <th:block th:replace="~{common/layout/footer :: footer}"></th:block>
+  </div>
+</main>
 
-  <script>
-    lucide.createIcons();
+<th:block th:replace="~{common/layout/footer :: footer}"></th:block>
 
-    /* ---- 드롭다운 / 모달 ---- */  </script>
-  <th:block th:replace="~{common/layout/header :: scripts}"></th:block>
+<script>
+  lucide.createIcons();
+
+  /* ---- 드롭다운 / 모달 ---- */
+
+  // ===== [추가] 폼 유효성 검사 및 금액 변환 로직 =====
+  let currentAmount = 0;
+
+  function handleAmountInput(input) {
+    const rawValue = input.value.replace(/[^0-9]/g, '');
+    currentAmount = rawValue ? parseInt(rawValue, 10) : 0;
+
+    input.value = currentAmount > 0 ? currentAmount.toLocaleString() : '';
+    document.getElementById('amountHidden').value = currentAmount;
+
+    const formattedEl = document.getElementById('amountFormatted');
+    if (currentAmount > 0) {
+      formattedEl.classList.remove('hidden');
+      formattedEl.textContent = currentAmount.toLocaleString() + '원';
+    } else {
+      formattedEl.classList.add('hidden');
+    }
+    checkForm();
+  }
+
+  function addAmount(amountToAdd) {
+    currentAmount += amountToAdd;
+    const input = document.getElementById('amountDisplay');
+    input.value = currentAmount.toLocaleString();
+    document.getElementById('amountHidden').value = currentAmount;
+
+    const formattedEl = document.getElementById('amountFormatted');
+    formattedEl.classList.remove('hidden');
+    formattedEl.textContent = currentAmount.toLocaleString() + '원';
+    checkForm();
+  }
+
+  function checkForm() {
+    const bank = document.getElementById('bankSelect').value;
+    const account = document.getElementById('accountNumber').value;
+    const password = document.getElementById('accountPassword').value;
+    const btn = document.getElementById('transferBtn');
+
+    // 은행, 계좌(최소 6자리 이상), 금액, 비밀번호(4자리) 확인
+    if (bank && account.length > 5 && currentAmount > 0 && password.length === 4) {
+      btn.disabled = false;
+      btn.classList.remove('bg-gray-200', 'text-gray-400', 'cursor-not-allowed');
+      btn.classList.add('bg-[#F5A5A5]', 'text-white', 'hover:bg-[#F28B8B]', 'shadow-md');
+    } else {
+      btn.disabled = true;
+      btn.classList.add('bg-gray-200', 'text-gray-400', 'cursor-not-allowed');
+      btn.classList.remove('bg-[#F5A5A5]', 'text-white', 'hover:bg-[#F28B8B]', 'shadow-md');
+    }
+  }
+
+  function handleTransfer(event) {
+    // 폼 제출 전 최종 확인이 필요하다면 여기에 로직 작성 가능
+    // 기본 제출을 막지 않음으로써 정상적으로 POST 백엔드 호출 진행됨
+  }
+</script>
+<th:block th:replace="~{common/layout/header :: scripts}"></th:block>
 </body>
 </html>


### PR DESCRIPTION
## 📌 작업 내용 (What)
- 금융 코어의 핵심인 **'간편 이체(송금)' 기능의 백엔드 연동 및 화면 흐름 제어**를 완료했습니다.
- 보안 강화를 위해 서비스 계층에 계좌 비밀번호 검증 로직을 추가하고 컨트롤러에 적용했습니다.

## 💡 주요 구현 포인트
- **UI & API 완벽 분리:** 타임리프 화면 이동을 담당하는 `TransferViewController`와 JSON 데이터를 반환하는 REST API용 `TransactionController`를 목적에 맞게 분리하여 연동했습니다.
- **예외 처리 및 뷰(View) 매핑:** 잔액 부족 및 한도 초과 시 발생하는 예외를 `try-catch`로 잡아, 뷰의 `addFlashAttribute`를 통해 실패 화면(`/transfer/failed`)으로 자연스럽게 에러 메시지를 전달합니다.

## 🛠️ 향후 계획 (Next Steps)
- 이 PR은 메인 `dev`가 아닌, 개인 통합 브랜치인 `epic/wonseok-features`로 병합됩니다.
- 병합 후 바로 Phase 2인 **[파트너 초대]** 작업에 돌입하겠습니다.