### PR TITLE
feat: 공동 계좌 개설 플로우 서버 연동 및 CSRF 버그 수정

### DIFF
--- a/src/main/java/com/intelliJ_JO/modam/config/WebMvcConfig.java
+++ b/src/main/java/com/intelliJ_JO/modam/config/WebMvcConfig.java
@@ -1,0 +1,20 @@
+package com.intelliJ_JO.modam.config;
+
+import com.intelliJ_JO.modam.global.interceptor.CsrfTokenEagerLoadInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Spring MVC 추가 설정 클래스
+ * - 인터셉터 등록 등 MVC 확장 설정을 관리한다
+ */
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        // 모든 뷰 요청에 대해 CSRF 토큰을 응답 커밋 전에 미리 초기화한다
+        registry.addInterceptor(new CsrfTokenEagerLoadInterceptor());
+    }
+}

--- a/src/main/java/com/intelliJ_JO/modam/domain/account/dto/AccountCreateRequestDto.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/account/dto/AccountCreateRequestDto.java
@@ -16,13 +16,15 @@ public class AccountCreateRequestDto {
     @NotNull(message = "계좌 유형(PERSONAL/GROUP)은 필수입니다.")
     private AccountType accountType;
 
+    // 계좌 애칭
+    private String acctAlias;
+
+    // 초기 입금액 (선택, 미입력 시 0)
+    private Long initialDeposit;
+
     @NotNull(message = "계좌 비밀번호는 필수입니다.")
     @Pattern(regexp = "^[0-9]{4}$", message = "계좌 비밀번호는 숫자 4자리여야 합니다.")
     private String password;
-
-    @NotNull(message = "계좌 비밀번호 확인은 필수입니다.")
-    @Pattern(regexp = "^[0-9]{4}$", message = "계좌 비밀번호 확인은 숫자 4자리여야 합니다.")
-    private String passwordConfirm;
 
     // 이체 한도
     private Long onceTransferLimit;
@@ -34,14 +36,16 @@ public class AccountCreateRequestDto {
     private String fundSource;
     private String deliveryAddress;
 
-    // 필수 약관 동의
+    // 공동 계좌 약관 동의 (공동 계좌 개설 시에만 사용)
     @AssertTrue(message = "서비스 이용약관 동의는 필수입니다.")
     private boolean agreeService;
+
+    @AssertTrue(message = "전자금융거래 이용약관 동의는 필수입니다.")
+    private boolean agreeFinance;
 
     @AssertTrue(message = "개인정보 처리방침 동의는 필수입니다.")
     private boolean agreePrivacy;
 
     // 선택 약관 동의
     private boolean agreeMarketing;
-    private boolean agreeThirdParty;
 }

--- a/src/main/java/com/intelliJ_JO/modam/domain/account/dto/AccountResponseDto.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/account/dto/AccountResponseDto.java
@@ -18,9 +18,12 @@ public class AccountResponseDto {
     private Long dailyTransferLimit;
     private LocalDateTime createdAt;
 
+    private String acctAlias;
+
     public AccountResponseDto(Account account) {
         this.id = account.getId();
         this.accountNumber = account.getAccountNumber();
+        this.acctAlias = account.getAcctAlias();
         this.accountType = account.getAccountType().name();
         this.status = account.getStatus().name();
         this.balance = account.getBalance();

--- a/src/main/java/com/intelliJ_JO/modam/domain/account/entity/Account.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/account/entity/Account.java
@@ -76,6 +76,23 @@ public class Account {
     @Column(name = "fund_src", length = 100)
     private String fundSource;
 
+    // 계좌 애칭 (NULL 허용)
+    @Column(name = "acct_alias", length = 30)
+    private String acctAlias;
+
+    // 공동 계좌 약관 동의 (개인 계좌는 NULL 허용)
+    @Column(name = "agree_service")
+    private Boolean agreeService;       // [필수] 모담 서비스 이용약관
+
+    @Column(name = "agree_finance")
+    private Boolean agreeFinance;       // [필수] 전자금융거래 이용약관
+
+    @Column(name = "agree_privacy")
+    private Boolean agreePrivacy;       // [필수] 개인정보 수집·이용 동의
+
+    @Column(name = "agree_marketing")
+    private Boolean agreeMarketing;     // [선택] 마케팅 정보 수신 동의
+
     // 생성 일시
     @CreationTimestamp
     @Column(name = "created_at", updatable = false, nullable = false)

--- a/src/main/java/com/intelliJ_JO/modam/domain/account/service/AccountService.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/account/service/AccountService.java
@@ -34,20 +34,26 @@ public class AccountService {
     // 계좌 개설 — 세션의 인증된 사용자를 개설자로 등록
     @Transactional
     public AccountResponseDto createAccount(AccountCreateRequestDto request, Member member) {
-        if (!request.getPassword().equals(request.getPasswordConfirm())) {
-            throw new IllegalArgumentException("계좌 비밀번호가 일치하지 않습니다.");
-        }
+        // 초기 입금액 (미입력 시 0)
+        long deposit = request.getInitialDeposit() != null ? request.getInitialDeposit() : 0L;
 
         Account account = Account.builder()
                 .accountNumber(generateAccountNumber())
                 .passwordHash(passwordEncoder.encode(request.getPassword()))
                 .accountType(request.getAccountType())
+                .acctAlias(request.getAcctAlias())
+                .balance(deposit)
+                .availableBalance(deposit)
                 .deliveryAddress(request.getDeliveryAddress())
                 .jobInfo(request.getJobInfo())
                 .tradePurpose(request.getTradePurpose())
                 .fundSource(request.getFundSource())
                 .onceTransferLimit(request.getOnceTransferLimit())
                 .dailyTransferLimit(request.getDailyTransferLimit())
+                .agreeService(request.isAgreeService())
+                .agreeFinance(request.isAgreeFinance())
+                .agreePrivacy(request.isAgreePrivacy())
+                .agreeMarketing(request.isAgreeMarketing())
                 .build();
 
         Account saved = accountRepository.save(account);

--- a/src/main/java/com/intelliJ_JO/modam/global/interceptor/CsrfTokenEagerLoadInterceptor.java
+++ b/src/main/java/com/intelliJ_JO/modam/global/interceptor/CsrfTokenEagerLoadInterceptor.java
@@ -1,0 +1,29 @@
+package com.intelliJ_JO.modam.global.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * CSRF 토큰 조기 초기화 인터셉터
+ *
+ * 문제: HTML 파일이 클 경우(~36KB), Tomcat 기본 응답 버퍼(8KB)가 일찍 커밋되어
+ *       th:action 처리 시 CSRF 세션을 새로 만들 수 없어 IllegalStateException 발생.
+ *
+ * 해결: preHandle 단계(뷰 렌더링 전)에서 _csrf 토큰을 강제로 resolve하여
+ *       세션 생성이 응답 커밋 전에 완료되도록 보장.
+ */
+public class CsrfTokenEagerLoadInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        // _csrf 속성은 지연(deferred) 초기화 객체로, getToken() 호출 시 세션을 생성하고 토큰을 저장한다.
+        // 뷰 렌더링 전에 강제 호출하여 응답 커밋 이전에 세션이 생성되도록 한다.
+        CsrfToken csrfToken = (CsrfToken) request.getAttribute("_csrf");
+        if (csrfToken != null) {
+            csrfToken.getToken();
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/intelliJ_JO/modam/global/view/AccountViewController.java
+++ b/src/main/java/com/intelliJ_JO/modam/global/view/AccountViewController.java
@@ -1,13 +1,33 @@
 package com.intelliJ_JO.modam.global.view;
 
+import com.intelliJ_JO.modam.config.security.CustomUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class AccountViewController {
 
     @GetMapping("/group-account/new")
-    public String groupAccountNew() {
+    public String groupAccountNew(@AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
+        // 로그인된 사용자의 이름과 전화번호를 폼에 pre-fill
+        if (userDetails != null) {
+            model.addAttribute("userName", userDetails.getMember().getName());
+
+            // 전화번호를 010-XXXX-XXXX 형식으로 변환해서 전달
+            String rawPhone = userDetails.getMember().getPhoneNo();
+            if (rawPhone != null) {
+                String digits = rawPhone.replaceAll("\\D", "");
+                String formatted = digits;
+                if (digits.length() == 11) {
+                    formatted = digits.substring(0, 3) + "-" + digits.substring(3, 7) + "-" + digits.substring(7);
+                } else if (digits.length() == 10) {
+                    formatted = digits.substring(0, 3) + "-" + digits.substring(3, 6) + "-" + digits.substring(6);
+                }
+                model.addAttribute("userPhone", formatted);
+            }
+        }
         return "domain/account/group-account-new";
     }
 }

--- a/src/main/resources/templates/domain/account/group-account-new.html
+++ b/src/main/resources/templates/domain/account/group-account-new.html
@@ -192,6 +192,7 @@
               <label class="block text-sm font-medium text-gray-700 mb-2">휴대폰 번호</label>
               <div class="flex gap-3">
                 <input type="tel" id="phoneNum" placeholder="010-0000-0000" maxlength="13"
+                       th:value="${userPhone}"
                        oninput="formatPhone(this)"
                        class="flex-1 px-5 py-4 border-2 border-gray-200 rounded-2xl focus:border-[#F5A5A5] focus:outline-none transition-colors"/>
                 <button id="sendCodeBtn" onclick="sendVerificationCode()"
@@ -354,8 +355,7 @@
               </div>
               <div class="flex items-center justify-between">
                 <span class="text-sm text-gray-600">계좌번호</span>
-                <span class="font-mono font-semibold text-gray-800"
-                      th:text="${newAccountNumber}">1002-1234-5678</span>
+                <span id="summaryAccountNumber" class="font-mono font-semibold text-gray-800">1002-1234-5678</span>
               </div>
               <div class="flex items-center justify-between">
                 <span class="text-sm text-gray-600">잔액</span>
@@ -624,7 +624,8 @@
       const front = document.getElementById('idFront').value;
       const back  = document.getElementById('idBack').value;
       const phone = document.getElementById('phoneNum').value.replace(/\D/g,'');
-      const ok = name && front.length === 6 && back.length === 7 && phone.length >= 10 && codeVerified;
+      // 인증번호 확인 완료 여부만으로 다음 버튼 활성화
+      const ok = codeVerified;
       const btn = document.getElementById('step2Btn');
       if (ok) {
         btn.disabled = false;
@@ -690,18 +691,54 @@
       const raw     = document.getElementById('initialDeposit').value.replace(/,/g,'');
       const deposit = raw ? parseInt(raw) : 0;
 
-      /* 완료 화면 정보 채우기 */
-      document.getElementById('summaryAlias').textContent   = alias;
-      document.getElementById('summaryBalance').textContent = '₩' + deposit.toLocaleString();
-      document.getElementById('summaryDate').textContent    =
-        new Date().toLocaleDateString('ko-KR', { year:'numeric', month:'2-digit', day:'2-digit' })
-                  .replace(/\. /g,'.').replace('.','.').slice(0,-1);
+      // PIN 4자리 조합
+      const pins = [...document.querySelectorAll('.pin-input')].map(el => el.value);
+      const password = pins.join('');
 
-      closeConfirmModal();
-      goStep(4);
+      // CSRF 토큰 (Spring Security 세션 기반)
+      const csrfToken = document.querySelector('input[name="_csrf"]').value;
 
-      /* 서버 제출 (Spring Boot 연동 시 활성화) */
-      // document.getElementById('openForm').submit();
+      const requestBody = {
+        accountType   : 'GROUP',
+        acctAlias     : alias,
+        initialDeposit: deposit,
+        password      : password,
+        agreeService  : termState[1],
+        agreeFinance  : termState[2],
+        agreePrivacy  : termState[3],
+        agreeMarketing: termState[4]
+      };
+
+      fetch('/api/accounts', {
+        method : 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-TOKEN' : csrfToken
+        },
+        body: JSON.stringify(requestBody)
+      })
+      .then(res => {
+        if (!res.ok) return res.json().then(err => { throw err; });
+        return res.json();
+      })
+      .then(data => {
+        // 서버 응답값으로 완료 화면 채우기
+        document.getElementById('summaryAlias').textContent   = data.data.acctAlias || alias;
+        document.getElementById('summaryBalance').textContent = '₩' + deposit.toLocaleString();
+        document.getElementById('summaryDate').textContent    =
+          new Date().toLocaleDateString('ko-KR', { year:'numeric', month:'2-digit', day:'2-digit' })
+                    .replace(/\. /g,'.').replace('.','.').slice(0,-1);
+
+        // 서버에서 발급된 실제 계좌번호 표시
+        document.getElementById('summaryAccountNumber').textContent = data.data.accountNumber;
+
+        closeConfirmModal();
+        goStep(4);
+      })
+      .catch(err => {
+        console.error('계좌 개설 실패:', err);
+        alert(err.message || '계좌 개설 중 오류가 발생했습니다.');
+      });
     }
 
     /* ========== 약관 모달 ========== */
@@ -718,6 +755,8 @@
     /* 초기화 */
     window.addEventListener('DOMContentLoaded', function() {
       lucide.createIcons();
+      // 서버에서 pre-fill된 필드(이름·전화번호)가 있을 경우 버튼 상태를 즉시 반영
+      checkStep2();
     });
   </script>
 </body>

--- a/src/main/resources/templates/domain/auth/signup-complete.html
+++ b/src/main/resources/templates/domain/auth/signup-complete.html
@@ -101,7 +101,8 @@
             <i data-lucide="heart" class="w-7 h-7"></i>
             <span class="text-lg">지금 개설하기</span>
           </a>
-          <a th:href="@{/login}"
+          <!-- 나중에 할게요: 랜딩 페이지로 이동 -->
+          <a th:href="@{/}"
              class="flex flex-col items-center gap-2 py-5 bg-gray-100 text-gray-600 rounded-2xl hover:bg-gray-200 transition-colors">
             <i data-lucide="clock" class="w-7 h-7"></i>
             <span class="text-lg">나중에 할게요</span>


### PR DESCRIPTION
[버그 수정]
- 대용량 HTML 렌더링 시 CSRF 세션 생성 오류 해결 CsrfTokenEagerLoadInterceptor 추가 및 WebMvcConfig에 등록
- 회원가입 완료 화면 '나중에 할게요' 버튼 링크 오류 수정 (/login → /)

[공동 계좌 개설 기능 연동]
- Account 엔티티에 acct_alias, agree_service, agree_finance, agree_privacy, agree_marketing 컬럼 추가 (개인 계좌는 NULL 허용)
- AccountCreateRequestDto에 acctAlias, initialDeposit 추가, agreeFinance 추가, passwordConfirm 제거
- AccountResponseDto에 acctAlias 추가
- AccountService.createAccount()에 신규 필드 저장 처리 및 초기 입금액 반영 로직 추가
- AccountViewController에서 로그인 사용자 이름·전화번호 모델에 전달

[프론트엔드]
- group-account-new.html: 계좌 개설 폼을 fetch POST /api/accounts 로 연동
- 인증번호 확인 완료 시 다음 버튼 활성화 조건 수정
- 전화번호 서버 pre-fill 적용
- Step 4 완료 화면에 서버 응답 실제 계좌번호 표시