### PR TITLE
FEAT: 마이페이지 코어 데이터 연동 및 프로필/알림 UI 개선

### DIFF
--- a/src/main/java/com/intelliJ_JO/modam/global/view/MypageViewController.java
+++ b/src/main/java/com/intelliJ_JO/modam/global/view/MypageViewController.java
@@ -6,6 +6,7 @@ import com.intelliJ_JO.modam.domain.account.entity.AccountMember;
 import com.intelliJ_JO.modam.domain.account.entity.InviteStatus;
 import com.intelliJ_JO.modam.domain.account.repository.AccountMemberRepository;
 import com.intelliJ_JO.modam.domain.member.entity.Member;
+import com.intelliJ_JO.modam.domain.member.repository.MemberRepository;
 import com.intelliJ_JO.modam.domain.member.service.MemberService;
 import com.intelliJ_JO.modam.domain.member.service.MyPageService;
 import com.intelliJ_JO.modam.global.view.DashboardService;
@@ -25,11 +26,17 @@ import java.util.List;
 public class MypageViewController {
 
     private final AccountMemberRepository accountMemberRepository;
+    private final MemberRepository memberRepository; // 🔥 DB 최신 조회를 위해 추가
     private final DashboardService dashboardService;
     private final MemberService memberService;
     private final MyPageService myPageService;
 
-    // 기본 /mypage 접근 시 프로필 화면으로 리다이렉트
+    // 🔥 세션 캐시 대신 DB 최신 데이터를 가져오는 헬퍼 메서드
+    private Member getFreshMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+    }
+
     @GetMapping("/mypage")
     public String mypageRedirect() {
         return "redirect:/mypage/profile";
@@ -40,10 +47,10 @@ public class MypageViewController {
     // =========================================================================
     @GetMapping("/mypage/profile")
     public String profilePage(@AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
-        // 공통 헤더 데이터(알림, 포인트 등) 적용
-        dashboardService.populateHeader(userDetails.getMember(), model);
+        Member freshMember = getFreshMember(userDetails.getMember().getId()); // 🔥 최신 데이터 조회
+        dashboardService.populateHeader(freshMember, model);
 
-        model.addAttribute("member", userDetails.getMember());
+        model.addAttribute("member", freshMember);
         model.addAttribute("activeMenu", "profile");
         return "domain/mypage/profile";
     }
@@ -83,7 +90,8 @@ public class MypageViewController {
     // =========================================================================
     @GetMapping("/mypage/accounts")
     public String accountsPage(@AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
-        populateAccountData(userDetails.getMember(), model);
+        Member freshMember = getFreshMember(userDetails.getMember().getId());
+        populateAccountData(freshMember, model);
         model.addAttribute("activeMenu", "accounts");
         return "domain/mypage/accounts";
     }
@@ -93,9 +101,10 @@ public class MypageViewController {
     // =========================================================================
     @GetMapping("/mypage/notifications")
     public String notificationsPage(@AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
-        dashboardService.populateHeader(userDetails.getMember(), model);
+        Member freshMember = getFreshMember(userDetails.getMember().getId()); // 🔥 최신 알림 설정값 조회
+        dashboardService.populateHeader(freshMember, model);
 
-        model.addAttribute("noti", userDetails.getMember());
+        model.addAttribute("noti", freshMember);
         model.addAttribute("activeMenu", "notifications");
         return "domain/mypage/notifications";
     }
@@ -121,11 +130,11 @@ public class MypageViewController {
     // =========================================================================
     @GetMapping("/mypage/items")
     public String itemsPage(@AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
-        Long memberId = userDetails.getMember().getId();
-        dashboardService.populateHeader(userDetails.getMember(), model);
+        Member freshMember = getFreshMember(userDetails.getMember().getId());
+        dashboardService.populateHeader(freshMember, model);
 
-        model.addAttribute("purchasedThemes", myPageService.getPurchasedThemes(memberId));
-        model.addAttribute("purchasedEmoticons", myPageService.getPurchasedEmoticons(memberId));
+        model.addAttribute("purchasedThemes", myPageService.getPurchasedThemes(freshMember.getId()));
+        model.addAttribute("purchasedEmoticons", myPageService.getPurchasedEmoticons(freshMember.getId()));
         model.addAttribute("activeMenu", "items");
         return "domain/mypage/items";
     }
@@ -146,9 +155,10 @@ public class MypageViewController {
     // =========================================================================
     @GetMapping("/mypage/cards")
     public String cardsPage(@AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
-        populateAccountData(userDetails.getMember(), model);
+        Member freshMember = getFreshMember(userDetails.getMember().getId());
+        populateAccountData(freshMember, model);
 
-        model.addAttribute("userName", userDetails.getMember().getName());
+        model.addAttribute("userName", freshMember.getName());
         model.addAttribute("cardIssued", false);
         model.addAttribute("cardDesign", "pink");
         model.addAttribute("cardType", "domestic");
@@ -162,9 +172,10 @@ public class MypageViewController {
     // =========================================================================
     @GetMapping("/mypage/close-account")
     public String closeAccountPage(@AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
-        populateAccountData(userDetails.getMember(), model);
+        Member freshMember = getFreshMember(userDetails.getMember().getId());
+        populateAccountData(freshMember, model);
 
-        model.addAttribute("userName", userDetails.getMember().getName());
+        model.addAttribute("userName", freshMember.getName());
         model.addAttribute("userPoints", 0);
         model.addAttribute("accountClosureStatus", "none");
         model.addAttribute("closureRequestedBy", "");
@@ -177,9 +188,10 @@ public class MypageViewController {
     // =========================================================================
     @GetMapping("/mypage/withdrawal")
     public String withdrawalPage(@AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
-        dashboardService.populateHeader(userDetails.getMember(), model);
+        Member freshMember = getFreshMember(userDetails.getMember().getId());
+        dashboardService.populateHeader(freshMember, model);
 
-        boolean hasActiveAccount = accountMemberRepository.findByMemberId(userDetails.getMember().getId()).stream()
+        boolean hasActiveAccount = accountMemberRepository.findByMemberId(freshMember.getId()).stream()
                 .anyMatch(am -> am.getInviteStatus() == InviteStatus.ACCEPT && "GROUP".equals(am.getAccount().getAccountType().name()));
 
         model.addAttribute("hasActiveAccount", hasActiveAccount);
@@ -189,19 +201,16 @@ public class MypageViewController {
 
     @PostMapping("/mypage/withdraw")
     public String processWithdrawal(@AuthenticationPrincipal CustomUserDetails userDetails, RedirectAttributes rttr) {
-        // TODO: 향후 회원 탈퇴 서비스 로직 연결 (memberService.withdraw 등)
         rttr.addFlashAttribute("successMsg", "회원 탈퇴가 완료되었습니다. 이용해 주셔서 감사합니다.");
         return "redirect:/";
     }
 
     // =========================================================================
-    // ===== 공통 계좌 데이터 추출 헬퍼 메서드 (반환 타입 void 적용 완료) =====
+    // 공통 헬퍼 메서드
     // =========================================================================
     private void populateAccountData(Member member, Model model) {
-        // 1. 헤더용 대시보드 공통 데이터 채우기 (조장님 작업분 수용)
         dashboardService.populateHeader(member, model);
 
-        // 2. 모임 통장 정보 추출
         List<AccountMember> memberships = accountMemberRepository.findByMemberId(member.getId());
         AccountMember myMembership = memberships.stream()
                 .filter(am -> am.getInviteStatus() == InviteStatus.ACCEPT)
@@ -242,13 +251,8 @@ public class MypageViewController {
             model.addAttribute("myContribution", 0.0);
             model.addAttribute("partnerContribution", 0.0);
         }
-
-        // 🚨 예전 방식인 return "domain/mypage/mypage"; 는 완전히 폐기되었습니다!
     }
 
-    // =========================================================================
-    // ===== 카드 발급 워크플로우 (유지) =====
-    // =========================================================================
     @GetMapping("/mypage/card/step1") public String cardStep1() { return "domain/mypage/card-step1"; }
     @GetMapping("/mypage/card/step2") public String cardStep2() { return "domain/mypage/card-step2"; }
     @GetMapping("/mypage/card/step3") public String cardStep3() { return "domain/mypage/card-step3"; }

--- a/src/main/resources/templates/domain/mypage/notifications.html
+++ b/src/main/resources/templates/domain/mypage/notifications.html
@@ -12,7 +12,6 @@
 <th:block th:replace="~{common/layout/header :: nav}"></th:block>
 
 <div class="flex flex-1">
-
     <th:block th:replace="~{common/layout/mypage-sidebar :: sidebar('notifications')}"></th:block>
 
     <main class="flex-1 p-8 overflow-y-auto">
@@ -131,7 +130,7 @@
       lucide.createIcons();
     });
 
-    let allNotifications = true;
+    let allNotifications = false;
 
     function toggleMasterNotification() {
       allNotifications = !allNotifications;
@@ -157,9 +156,10 @@
     function toggleNotification(key) {
       const cap = key.charAt(0).toUpperCase() + key.slice(1);
       const inputEl = document.getElementById('val' + cap);
-      const newState = (inputEl.value === 'N'); // 토글
+      const newState = (inputEl.value === 'N');
       inputEl.value = newState ? 'Y' : 'N';
       updateSubToggle(key, newState);
+      checkMasterStatus(); // 상태 변경 시 마스터 토글 재계산
     }
 
     function updateSubToggle(key, enabled) {
@@ -176,12 +176,31 @@
       }
     }
 
+    // 🔥 하위 토글 4개가 모두 켜져있는지 확인하여 마스터 토글 동기화
+    function checkMasterStatus() {
+      const allOn = ['Deposit','Withdrawal','Weekly','Monthly']
+        .every(cap => document.getElementById('val' + cap).value === 'Y');
+
+      allNotifications = allOn;
+      const btnAll = document.getElementById('toggleAll');
+      const thumbAll = document.getElementById('thumbAll');
+
+      if (allNotifications) {
+        btnAll.classList.remove('bg-gray-300'); btnAll.classList.add('bg-[#F5A5A5]');
+        thumbAll.classList.remove('translate-x-0'); thumbAll.classList.add('translate-x-7');
+      } else {
+        btnAll.classList.remove('bg-[#F5A5A5]'); btnAll.classList.add('bg-gray-300');
+        thumbAll.classList.remove('translate-x-7'); thumbAll.classList.add('translate-x-0');
+      }
+    }
+
     function initNotificationUI() {
       ['deposit','withdrawal','weekly','monthly'].forEach(key => {
         const cap = key.charAt(0).toUpperCase() + key.slice(1);
         const val = document.getElementById('val' + cap).value;
         updateSubToggle(key, val === 'Y');
       });
+      checkMasterStatus(); // 페이지 첫 로드 시 마스터 상태 세팅
     }
 </script>
 <th:block th:replace="~{common/layout/header :: scripts}"></th:block>

--- a/src/main/resources/templates/domain/mypage/profile.html
+++ b/src/main/resources/templates/domain/mypage/profile.html
@@ -20,62 +20,87 @@
         <div id="section-profile" class="max-w-4xl">
             <h1 class="text-2xl font-bold text-gray-800 mb-8">프로필 정보</h1>
 
+            <div th:if="${successMsg}" class="mb-6 p-4 bg-green-50 border border-green-200 text-green-700 rounded-xl flex items-center gap-2">
+                <i data-lucide="check-circle" class="w-5 h-5"></i>
+                <span th:text="${successMsg}"></span>
+            </div>
+            <div th:if="${errorMsg}" class="mb-6 p-4 bg-red-50 border border-red-200 text-red-700 rounded-xl flex items-center gap-2">
+                <i data-lucide="alert-circle" class="w-5 h-5"></i>
+                <span th:text="${errorMsg}"></span>
+            </div>
+
             <div class="bg-white rounded-3xl shadow-sm p-8 mb-6">
                 <h2 class="text-lg font-bold text-gray-800 mb-6">내 정보</h2>
                 <div class="flex items-start gap-8">
+
                     <div class="flex flex-col items-center">
-                        <div class="w-32 h-32 rounded-full bg-[#FCE8E3] flex items-center justify-center mb-4 relative group cursor-pointer">
-                            <i data-lucide="user" class="w-16 h-16 text-gray-400"></i>
+                        <input type="file" id="profileFile" accept="image/*" class="hidden" onchange="previewImage(this)">
+
+                        <label for="profileFile" class="relative group cursor-pointer block">
+                            <div th:if="${member != null and member.profileImg != null}" class="w-32 h-32 rounded-full overflow-hidden mb-4 border-2 border-gray-100">
+                                <img id="profileImagePreview" th:src="${member.profileImg}" alt="프로필 사진" class="w-full h-full object-cover"/>
+                            </div>
+                            <div th:unless="${member != null and member.profileImg != null}" id="profileIconWrapper"
+                                 class="w-32 h-32 rounded-full bg-[#FCE8E3] flex items-center justify-center mb-4 border-2 border-gray-100 overflow-hidden">
+                                <i data-lucide="user" class="w-16 h-16 text-gray-400"></i>
+                                <img id="profileImagePreview" class="hidden w-full h-full object-cover"/>
+                            </div>
+
                             <div class="absolute inset-0 rounded-full bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
                                 <i data-lucide="camera" class="w-8 h-8 text-white"></i>
                             </div>
-                        </div>
-                        <button class="px-4 py-2 bg-gray-100 text-gray-700 rounded-xl hover:bg-gray-200 transition-colors text-sm">사진 변경</button>
+                        </label>
+
+                        <button onclick="document.getElementById('profileFile').click()"
+                                class="px-4 py-2 bg-gray-100 text-gray-700 rounded-xl hover:bg-gray-200 transition-colors text-sm">
+                            사진 변경
+                        </button>
                     </div>
 
                     <form th:action="@{/mypage/profile/update}" method="post" class="flex-1 space-y-4">
                         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                         <div class="grid grid-cols-2 gap-4">
                             <div>
-                                <label class="block text-sm text-gray-600 mb-2">이름</label>
+                                <label class="block text-sm text-gray-600 mb-2">이름 (변경 불가)</label>
                                 <input type="text" id="profileName" name="name"
                                        th:value="${member != null ? member.name : '김민수'}"
-                                       class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-[#FCE8E3] focus:outline-none transition-colors"/>
+                                       class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl bg-gray-50 text-gray-500 cursor-not-allowed" readonly/>
                             </div>
                             <div>
                                 <label class="block text-sm text-gray-600 mb-2">아이디 (변경 불가)</label>
                                 <input type="text" th:value="${member != null ? member.userId : 'minsu_kim'}"
-                                       class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl bg-gray-50" disabled/>
+                                       class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl bg-gray-50 text-gray-500 cursor-not-allowed" disabled/>
                             </div>
                         </div>
                         <div>
                             <label class="block text-sm text-gray-600 mb-2">이메일 (변경 불가)</label>
                             <input type="email" id="profileEmail"
                                    th:value="${member != null ? member.email : 'minsu.kim@email.com'}"
-                                   class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl bg-gray-50" disabled/>
+                                   class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl bg-gray-50 text-gray-500 cursor-not-allowed" disabled/>
                         </div>
                         <div>
-                            <label class="block text-sm text-gray-600 mb-2">연락처</label>
+                            <label class="block text-sm text-gray-600 mb-2">휴대폰 번호</label>
                             <input type="tel" id="profilePhone" name="phoneNo"
                                    th:value="${member != null ? member.phoneNo : '010-1234-5678'}"
-                                   class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-[#FCE8E3] focus:outline-none transition-colors"/>
+                                   class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-[#FCE8E3] focus:outline-none transition-colors"
+                                   oninput="formatPhone(this)" maxlength="13" required/>
                         </div>
-                        <button type="submit" onclick="return handleProfileUpdate()"
-                                class="w-full py-3 bg-[#FCE8E3] text-gray-800 rounded-xl hover:bg-[#FBD5CE] transition-colors mt-4 font-medium">정보 수정 저장하기</button>
+                        <button type="submit" class="w-full py-3 bg-[#FCE8E3] text-gray-800 rounded-xl hover:bg-[#FBD5CE] transition-colors mt-4 font-medium">정보 수정 저장하기</button>
                     </form>
                 </div>
             </div>
 
             <div class="bg-white rounded-3xl shadow-sm p-8">
                 <h2 class="text-lg font-bold text-gray-800 mb-6">보안 설정</h2>
-                <form th:action="@{/mypage/password/update}" method="post" onsubmit="return handlePasswordChange(event)">
+                <form th:action="@{/mypage/password/update}" method="post">
                     <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                     <div class="space-y-4">
                         <div>
                             <label class="block text-sm text-gray-600 mb-2">현재 비밀번호</label>
                             <div class="relative">
                                 <input type="password" id="currentPw" name="currentPassword" placeholder="현재 비밀번호를 입력하세요"
-                                       class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-[#FCE8E3] focus:outline-none transition-colors pr-12"/>
+                                       class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-[#FCE8E3] focus:outline-none transition-colors pr-12"
+                                       oninput="validatePasswordForm()"/>
                                 <button type="button" onclick="togglePw('currentPw','eyeCurrent')" class="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">
                                     <i data-lucide="eye" id="eyeCurrent" class="w-5 h-5"></i>
                                 </button>
@@ -84,24 +109,33 @@
                         <div>
                             <label class="block text-sm text-gray-600 mb-2">새 비밀번호</label>
                             <div class="relative">
-                                <input type="password" id="newPw" name="newPassword" placeholder="새 비밀번호를 입력하세요"
-                                       class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-[#FCE8E3] focus:outline-none transition-colors pr-12"/>
+                                <input type="password" id="newPw" name="newPassword" placeholder="영문, 숫자, 특수문자 조합 8-20자"
+                                       class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:outline-none transition-colors pr-12"
+                                       minlength="8" maxlength="20" oninput="validatePasswordForm()"/>
                                 <button type="button" onclick="togglePw('newPw','eyeNew')" class="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">
                                     <i data-lucide="eye" id="eyeNew" class="w-5 h-5"></i>
                                 </button>
                             </div>
+                            <p id="newPwLengthError" class="hidden text-sm text-red-500 mt-1">비밀번호는 8자 이상이어야 합니다.</p>
                         </div>
                         <div>
                             <label class="block text-sm text-gray-600 mb-2">새 비밀번호 확인</label>
                             <div class="relative">
                                 <input type="password" id="confirmPw" name="confirmPassword" placeholder="새 비밀번호를 다시 입력하세요"
-                                       class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-[#FCE8E3] focus:outline-none transition-colors pr-12"/>
+                                       class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:outline-none transition-colors pr-12"
+                                       maxlength="20" oninput="validatePasswordForm()"/>
                                 <button type="button" onclick="togglePw('confirmPw','eyeConfirm')" class="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">
                                     <i data-lucide="eye" id="eyeConfirm" class="w-5 h-5"></i>
                                 </button>
                             </div>
+                            <p id="pwMatchError" class="hidden text-sm text-red-500 mt-1">비밀번호가 일치하지 않습니다.</p>
+                            <p id="pwMatchSuccess" class="hidden text-sm text-green-500 mt-1">비밀번호가 일치합니다.</p>
                         </div>
-                        <button type="submit" class="w-full py-3 bg-[#FCE8E3] text-gray-800 rounded-xl hover:bg-[#FBD5CE] transition-colors mt-4 font-medium">비밀번호 변경</button>
+
+                        <button type="submit" id="pwSubmitBtn" disabled
+                                class="w-full py-3 bg-gray-200 text-gray-400 rounded-xl transition-colors mt-4 font-medium cursor-not-allowed">
+                            비밀번호 변경
+                        </button>
                     </div>
                 </form>
             </div>
@@ -115,6 +149,7 @@
 <script>
     window.addEventListener('DOMContentLoaded', () => { lucide.createIcons(); });
 
+    // 눈동자 아이콘 비밀번호 보이기/숨기기
     function togglePw(inputId, iconId) {
       const input = document.getElementById(inputId);
       const icon  = document.getElementById(iconId);
@@ -128,21 +163,105 @@
       lucide.createIcons();
     }
 
-    function handleProfileUpdate() {
-      const name  = document.getElementById('profileName').value;
-      const phone = document.getElementById('profilePhone').value;
-      if (!name || !phone) { alert('모든 항목을 입력해주세요.'); return false; }
-      return true;
+    // 휴대폰 번호 자동 하이픈 및 제한 포맷팅 (회원가입에서 이식)
+    function formatPhone(input) {
+      const digits = input.value.replace(/[^0-9]/g, '').slice(0, 11);
+      if (digits.length < 4)       input.value = digits;
+      else if (digits.length < 8)  input.value = digits.slice(0, 3) + '-' + digits.slice(3);
+      else                         input.value = digits.slice(0, 3) + '-' + digits.slice(3, 7) + '-' + digits.slice(7);
     }
 
-    function handlePasswordChange(e) {
-      const cur = document.getElementById('currentPw').value;
-      const newPw = document.getElementById('newPw').value;
-      const confirm = document.getElementById('confirmPw').value;
-      if (!cur || !newPw || !confirm) { alert('모든 항목을 입력해주세요.'); e.preventDefault(); return false; }
-      if (newPw.length < 8) { alert('새 비밀번호는 8자 이상이어야 합니다.'); e.preventDefault(); return false; }
-      if (newPw !== confirm) { alert('새 비밀번호와 확인이 일치하지 않습니다.'); e.preventDefault(); return false; }
-      return true;
+    // 비밀번호 실시간 유효성 검사 및 UI 변경
+    function validatePasswordForm() {
+        const currentPw = document.getElementById('currentPw').value;
+        const newPw = document.getElementById('newPw').value;
+        const confirmPw = document.getElementById('confirmPw').value;
+
+        const newPwInput = document.getElementById('newPw');
+        const confirmPwInput = document.getElementById('confirmPw');
+
+        const lenError = document.getElementById('newPwLengthError');
+        const matchError = document.getElementById('pwMatchError');
+        const matchSuccess = document.getElementById('pwMatchSuccess');
+        const btn = document.getElementById('pwSubmitBtn');
+
+        let isLengthValid = false;
+        let isMatchValid = false;
+
+        // 1. 새 비밀번호 길이 검사 (8자 이상)
+        if (newPw.length > 0 && newPw.length < 8) {
+            newPwInput.classList.remove('border-gray-200', 'border-green-400', 'focus:border-[#FCE8E3]');
+            newPwInput.classList.add('border-red-400');
+            lenError.classList.remove('hidden');
+        } else if (newPw.length >= 8) {
+            newPwInput.classList.remove('border-red-400', 'focus:border-[#FCE8E3]');
+            newPwInput.classList.add('border-green-400');
+            lenError.classList.add('hidden');
+            isLengthValid = true;
+        } else {
+            newPwInput.classList.remove('border-red-400', 'border-green-400');
+            newPwInput.classList.add('border-gray-200', 'focus:border-[#FCE8E3]');
+            lenError.classList.add('hidden');
+        }
+
+        // 2. 비밀번호 일치 검사
+        if (confirmPw.length > 0) {
+            if (newPw === confirmPw && isLengthValid) {
+                confirmPwInput.classList.remove('border-red-400', 'border-gray-200', 'focus:border-[#FCE8E3]');
+                confirmPwInput.classList.add('border-green-400');
+                matchError.classList.add('hidden');
+                matchSuccess.classList.remove('hidden');
+                isMatchValid = true;
+            } else {
+                confirmPwInput.classList.remove('border-green-400', 'border-gray-200', 'focus:border-[#FCE8E3]');
+                confirmPwInput.classList.add('border-red-400');
+                matchError.classList.remove('hidden');
+                matchSuccess.classList.add('hidden');
+            }
+        } else {
+            confirmPwInput.classList.remove('border-red-400', 'border-green-400');
+            confirmPwInput.classList.add('border-gray-200', 'focus:border-[#FCE8E3]');
+            matchError.classList.add('hidden');
+            matchSuccess.classList.add('hidden');
+        }
+
+        // 3. 버튼 활성화 제어
+        if (currentPw.trim() !== '' && isLengthValid && isMatchValid) {
+            btn.disabled = false;
+            btn.className = 'w-full py-3 bg-[#FCE8E3] text-gray-800 rounded-xl hover:bg-[#FBD5CE] transition-colors mt-4 font-medium cursor-pointer';
+        } else {
+            btn.disabled = true;
+            btn.className = 'w-full py-3 bg-gray-200 text-gray-400 rounded-xl transition-colors mt-4 font-medium cursor-not-allowed';
+        }
+    }
+
+    // 🔥 [추가됨] 프론트엔드 이미지 실시간 미리보기 (서버 전송 없음)
+    function previewImage(input) {
+        if (input.files && input.files[0]) {
+            const file = input.files[0];
+            const reader = new FileReader();
+
+            reader.onload = function(e) {
+                const previewImg = document.getElementById('profileImagePreview');
+                const iconWrapper = document.getElementById('profileIconWrapper');
+
+                // 1. 이미지 소스 적용 및 보여주기
+                previewImg.src = e.target.result;
+                previewImg.classList.remove('hidden');
+
+                // 2. 기본 아이콘이 있던 경우 아이콘 숨기고 이미지 컨테이너로 스타일 변경
+                if (iconWrapper) {
+                    // 아이콘 래퍼 안의 i 태그(루사이드 아이콘) 숨기기
+                    const icon = iconWrapper.querySelector('i');
+                    if(icon) icon.classList.add('hidden');
+
+                    // 아이콘 래퍼 자체를 이미지 컨테이너 스타일로 변경
+                    iconWrapper.classList.remove('bg-[#FCE8E3]', 'flex', 'items-center', 'justify-center');
+                }
+            }
+
+            reader.readAsDataURL(file);
+        }
     }
 </script>
 <th:block th:replace="~{common/layout/header :: scripts}"></th:block>


### PR DESCRIPTION
## 🔍 작업 내용
마이페이지의 뷰(View) 렌더링 방식과 코어 데이터(프로필, 알림, 아이템) 연동을 완벽하게 구현했습니다.

 - Closes : #106 

1. **DB 최신화 동기화:** - 기존 세션(`userDetails`)에 의존하던 렌더링 방식을 변경하여, 컨트롤러가 호출될 때마다 DB에서 최신 `Member` 정보를 꺼내오도록(`getFreshMember`) 수정했습니다.
2. **알림 및 아이템 서비스 연동:** - `Member` 엔티티에 알림 설정 컬럼을 추가하고, `MyPageService`를 통해 알림 토글 상태 및 인벤토리(아이템 장착) 상태가 DB에 즉각 반영되도록 구현했습니다.
3. **UI/UX 디테일 고도화 (Frontend):**
   - **프로필:** 비밀번호 실시간 유효성 검사(조건 미충족 시 빨간 테두리 및 버튼 비활성화), 휴대폰 번호 포맷팅(자동 하이픈), 프로필 사진 실시간 미리보기 기능을 추가했습니다.
   - **알림:** 하위 토글 상태에 따라 '모든 알림 받기' 마스터 토글이 자동으로 동기화되도록 JS 로직을 수정했습니다.

## ⚠️ 리뷰어에게
- 본 PR에는 **프로필 사진의 '서버 업로드' 로직은 포함되어 있지 않습니다.** (프론트엔드 미리보기까지만 구현됨)
- 계좌 해지, 회원 탈퇴, 카드 관리 등의 금융 비즈니스 로직은 추후 별도의 브랜치에서 진행될 예정입니다.