### PR TITLE
FIX: 프로필 사진 및 텍스트 정보 동시 저장 누락 버그 수정 (QA 반영)

### DIFF
--- a/src/main/java/com/intelliJ_JO/modam/global/view/MypageViewController.java
+++ b/src/main/java/com/intelliJ_JO/modam/global/view/MypageViewController.java
@@ -17,13 +17,10 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
@@ -35,6 +32,7 @@ public class MypageViewController {
     private final MemberService memberService;
     private final MyPageService myPageService;
 
+    // 세션 캐시 방지 및 최신 DB 데이터 조회를 위한 헬퍼 메서드
     private Member getFreshMember(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
@@ -46,7 +44,7 @@ public class MypageViewController {
     }
 
     // =========================================================================
-    // 1. 프로필 관리 + 🔥 비동기 이미지 파일 업로드 추가
+    // 1. 프로필 관리
     // =========================================================================
     @GetMapping("/mypage/profile")
     public String profilePage(@AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
@@ -62,33 +60,25 @@ public class MypageViewController {
     public String updateProfile(
             @RequestParam String name,
             @RequestParam String phoneNo,
+            @RequestParam(value = "profileImage", required = false) MultipartFile profileImage, // 🔥 이미지 파일 수신 파라미터 통합 추가
             @AuthenticationPrincipal CustomUserDetails userDetails,
             RedirectAttributes rttr) {
         try {
-            memberService.updateMyPageProfile(userDetails.getMember().getId(), name, phoneNo);
+            Long memberId = userDetails.getMember().getId();
+
+            // 1. 이름 및 휴대폰 번호 텍스트 정보 업데이트
+            memberService.updateMyPageProfile(memberId, name, phoneNo);
+
+            // 2. 🔥 사용자가 프로필 사진을 새로 선택하여 전송한 경우 서버 로컬 저장 및 DB 갱신 수행
+            if (profileImage != null && !profileImage.isEmpty()) {
+                myPageService.uploadProfileImage(memberId, profileImage);
+            }
+
             rttr.addFlashAttribute("successMsg", "프로필 정보가 성공적으로 수정되었습니다.");
         } catch (Exception e) {
-            rttr.addFlashAttribute("errorMsg", "프로필 수정 중 오류가 발생했습니다.");
+            rttr.addFlashAttribute("errorMsg", "프로필 수정 중 오류가 발생했습니다: " + e.getMessage());
         }
         return "redirect:/mypage/profile";
-    }
-
-    // 🔥 [추가됨] 프론트엔드 비동기(Fetch) 파일 수신 엔드포인트 구현 (JSON 응답 반환)
-    @PostMapping("/mypage/profile/image-upload")
-    @ResponseBody
-    public Map<String, Object> uploadProfileImage(
-            @RequestParam("profileFile") MultipartFile file,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Map<String, Object> response = new HashMap<>();
-        try {
-            String savedImgUrl = myPageService.uploadProfileImage(userDetails.getMember().getId(), file);
-            response.put("success", true);
-            response.put("imgUrl", savedImgUrl);
-        } catch (Exception e) {
-            response.put("success", false);
-            response.put("message", e.getMessage());
-        }
-        return response;
     }
 
     @PostMapping("/mypage/password/update")
@@ -227,7 +217,7 @@ public class MypageViewController {
     }
 
     // =========================================================================
-    // 공통 헬퍼 메서드
+    // 공통 금융 데이터 추출 헬퍼 메서드
     // =========================================================================
     private void populateAccountData(Member member, Model model) {
         dashboardService.populateHeader(member, model);
@@ -274,6 +264,7 @@ public class MypageViewController {
         }
     }
 
+    // 카드 발급 워크플로우 전용 스텝 라우터 경로 매핑
     @GetMapping("/mypage/card/step1") public String cardStep1() { return "domain/mypage/card-step1"; }
     @GetMapping("/mypage/card/step2") public String cardStep2() { return "domain/mypage/card-step2"; }
     @GetMapping("/mypage/card/step3") public String cardStep3() { return "domain/mypage/card-step3"; }

--- a/src/main/resources/templates/domain/mypage/profile.html
+++ b/src/main/resources/templates/domain/mypage/profile.html
@@ -31,10 +31,12 @@
 
             <div class="bg-white rounded-3xl shadow-sm p-8 mb-6">
                 <h2 class="text-lg font-bold text-gray-800 mb-6">내 정보</h2>
-                <div class="flex items-start gap-8">
+
+                <form th:action="@{/mypage/profile/update}" method="post" enctype="multipart/form-data" class="flex items-start gap-8 w-full">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
 
                     <div class="flex flex-col items-center">
-                        <input type="file" id="profileFile" accept="image/*" class="hidden" onchange="previewImage(this)">
+                        <input type="file" id="profileFile" name="profileImage" accept="image/*" class="hidden" onchange="previewImage(this)">
 
                         <label for="profileFile"
                                class="relative group cursor-pointer block w-32 h-32 rounded-full overflow-hidden mb-4 border-2 border-gray-100 shadow-inner bg-gray-50">
@@ -60,43 +62,42 @@
                             </div>
                         </label>
 
-                        <button onclick="document.getElementById('profileFile').click()"
+                        <button type="button" onclick="document.getElementById('profileFile').click()"
                                 class="px-4 py-2 bg-gray-100 text-gray-700 rounded-xl hover:bg-gray-200 transition-colors text-sm">
                             사진 변경
                         </button>
                     </div>
 
-                    <form th:action="@{/mypage/profile/update}" method="post" class="flex-1 space-y-4">
-                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <div class="flex-1 space-y-4">
                         <div class="grid grid-cols-2 gap-4">
                             <div>
                                 <label class="block text-sm text-gray-600 mb-2">이름 (변경 불가)</label>
                                 <input type="text" id="profileName" name="name"
-                                       th:value="${member != null ? member.name : '김민수'}"
+                                       th:value="${member != null ? member.name : ''}"
                                        class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl bg-gray-50 text-gray-500 cursor-not-allowed" readonly/>
                             </div>
                             <div>
                                 <label class="block text-sm text-gray-600 mb-2">아이디 (변경 불가)</label>
-                                <input type="text" th:value="${member != null ? member.userId : 'minsu_kim'}"
+                                <input type="text" th:value="${member != null ? member.userId : ''}"
                                        class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl bg-gray-50 text-gray-500 cursor-not-allowed" disabled/>
                             </div>
                         </div>
                         <div>
                             <label class="block text-sm text-gray-600 mb-2">이메일 (변경 불가)</label>
                             <input type="email" id="profileEmail"
-                                   th:value="${member != null ? member.email : 'minsu.kim@email.com'}"
+                                   th:value="${member != null ? member.email : ''}"
                                    class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl bg-gray-50 text-gray-500 cursor-not-allowed" disabled/>
                         </div>
                         <div>
                             <label class="block text-sm text-gray-600 mb-2">휴대폰 번호</label>
                             <input type="tel" id="profilePhone" name="phoneNo"
-                                   th:value="${member != null ? member.phoneNo : '010-1234-5678'}"
+                                   th:value="${member != null ? member.phoneNo : ''}"
                                    class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-[#FCE8E3] focus:outline-none transition-colors"
                                    oninput="formatPhone(this)" maxlength="13" required/>
                         </div>
                         <button type="submit" class="w-full py-3 bg-[#FCE8E3] text-gray-800 rounded-xl hover:bg-[#FBD5CE] transition-colors mt-4 font-medium">정보 수정 저장하기</button>
-                    </form>
-                </div>
+                    </div>
+                </form>
             </div>
 
             <div class="bg-white rounded-3xl shadow-sm p-8">
@@ -158,7 +159,6 @@
 <script>
     window.addEventListener('DOMContentLoaded', () => { lucide.createIcons(); });
 
-    // 눈동자 아이콘 비밀번호 보이기/숨기기
     function togglePw(inputId, iconId) {
       const input = document.getElementById(inputId);
       const icon  = document.getElementById(iconId);
@@ -172,7 +172,6 @@
       lucide.createIcons();
     }
 
-    // 휴대폰 번호 자동 하이픈 및 제한 포맷팅 (회원가입에서 이식)
     function formatPhone(input) {
       const digits = input.value.replace(/[^0-9]/g, '').slice(0, 11);
       if (digits.length < 4)       input.value = digits;
@@ -180,7 +179,6 @@
       else                         input.value = digits.slice(0, 3) + '-' + digits.slice(3, 7) + '-' + digits.slice(7);
     }
 
-    // 비밀번호 실시간 유효성 검사 및 UI 변경
     function validatePasswordForm() {
         const currentPw = document.getElementById('currentPw').value;
         const newPw = document.getElementById('newPw').value;
@@ -197,7 +195,6 @@
         let isLengthValid = false;
         let isMatchValid = false;
 
-        // 1. 새 비밀번호 길이 검사 (8자 이상)
         if (newPw.length > 0 && newPw.length < 8) {
             newPwInput.classList.remove('border-gray-200', 'border-green-400', 'focus:border-[#FCE8E3]');
             newPwInput.classList.add('border-red-400');
@@ -208,13 +205,11 @@
             lenError.classList.add('hidden');
             isLengthValid = true;
         } else {
-            // 비어있을 때 초기화
             newPwInput.classList.remove('border-red-400', 'border-green-400');
             newPwInput.classList.add('border-gray-200', 'focus:border-[#FCE8E3]');
             lenError.classList.add('hidden');
         }
 
-        // 2. 비밀번호 일치 검사
         if (confirmPw.length > 0) {
             if (newPw === confirmPw && isLengthValid) {
                 confirmPwInput.classList.remove('border-red-400', 'border-gray-200', 'focus:border-[#FCE8E3]');
@@ -229,14 +224,12 @@
                 matchSuccess.classList.add('hidden');
             }
         } else {
-            // 비어있을 때 초기화
             confirmPwInput.classList.remove('border-red-400', 'border-green-400');
             confirmPwInput.classList.add('border-gray-200', 'focus:border-[#FCE8E3]');
             matchError.classList.add('hidden');
             matchSuccess.classList.add('hidden');
         }
 
-        // 3. 버튼 활성화 제어 (모든 조건 충족 시)
         if (currentPw.trim() !== '' && isLengthValid && isMatchValid) {
             btn.disabled = false;
             btn.className = 'w-full py-3 bg-[#FCE8E3] text-gray-800 rounded-xl hover:bg-[#FBD5CE] transition-colors mt-4 font-medium cursor-pointer';
@@ -246,8 +239,7 @@
         }
     }
 
-    // 🔥 [추가됨] 프론트엔드 이미지 실시간 미리보기 (서버 전송 없음)
-    // ⚠️ 윈도우/맥 간 stetching 에러 해결을 위해 HTML을 완전히 교체하는 방식으로 로직 변경
+    // 파일 업로드 시 클라이언트 측 동적 이미지 프리뷰 반영 로직
     function previewImage(input) {
         if (input.files && input.files[0]) {
             const file = input.files[0];
@@ -255,22 +247,16 @@
 
             reader.onload = function(e) {
                 const container = document.getElementById('profileImageContainer');
-
-                // 1. 기존 컨테이너 내부(아이콘 또는 옛날 사진)를 완전히 깨끗하게 비움
                 container.innerHTML = '';
 
-                // 2. 새로운 img 태그를 자바스크립트로 직접 생성
                 const newImg = document.createElement('img');
                 newImg.id = 'profileImagePreview';
-                newImg.src = e.target.result; // 사용자가 선택한 이미지의 임시 경로 바인딩
+                newImg.src = e.target.result;
                 newImg.alt = 'Profile';
-                // 윈도우/맥 stetching을 차단하는 가장 확실한 스타일 강제 주입
                 newImg.className = 'w-full h-full object-cover';
 
-                // 3. 깨끗해진 컨테이너에 새로운 이미지를 주입
                 container.appendChild(newImg);
             }
-
             reader.readAsDataURL(file);
         }
     }


### PR DESCRIPTION
## 🔍 작업 내용
다른 팀원들이 QA를 진행하는 과정에서 발견된 **"프로필 사진을 변경한 뒤 '정보 수정 저장하기' 버튼을 누르면 실제 DB 및 로컬 서버스토리지에 반영되지 않는 문제"**를 전면 수정했습니다.

### 1. 원인 분석
- 기존 로직은 사진 파일 선택창(`<input type="file">`)이 연락처와 이름을 변경하는 `<form>` 태그 외부에 독립적으로 배치되어 있었습니다.
- 이로 인해 정보 수정 폼 서브밋(Submit) 시점에 이미지 바이너리 데이터가 서버로 함께 전송되지 못했으며, 멀티파트 인코딩 타입(`enctype`) 설정 역시 누락되어 있었습니다.

### 2. 해결 방안 및 반영 사항
- **Frontend (`profile.html`)**
  - 전체 레이아웃 구조를 개조하여 이미지 선택 영역부터 하단 텍스트 입력창까지 하나의 단일 `<form>` 태그가 모두 감싸도록 동선과 스코프를 일치시켰습니다.
  - 대용량 파일 전송을 위해 폼 태그에 `enctype="multipart/form-data"` 속성을 부여하고, 파일 인풋 태그에 `name="profileImage"` 속성을 명시했습니다.
- **Backend (`MypageViewController`)**
  - `@PostMapping("/mypage/profile/update")` 메서드 파라미터에 `@RequestParam(value = "profileImage", required = false) MultipartFile profileImage`를 새롭게 추가하여 텍스트 필드와 사진 파일 객체를 한 번에 수신하도록 통합했습니다.
  - 컨트롤러 내부에서 회원 기본 정보 수정이 성공적으로 끝난 직후, 넘어온 이미지 객체 검증을 거쳐 `myPageService.uploadProfileImage`를 즉각 실행해 단일 흐름으로 사진 정보까지 안전하게 갱신되도록 구조화했습니다.

## ⚠️ 리뷰어에게
- 수정 사항을 반영한 후, 프로필 수정 페이지에서 사진과 전화번호를 바꾼 뒤 저장했을 때 파일 시스템에 물리 파일이 고유 UUID 명명 규칙에 맞춰 정상 보존되며 새로고침 후에도 마이페이지 뷰 전반에 데이터가 완벽하게 실시간 동기화되는 것을 확인했습니다.
- 본 버그 픽스 내역이 병합되는 대로 곧바로 8단계 카드 발급 워크플로우 전용 테스트 브랜치(`feat/mypage-card-workflow`) 작업을 진행하겠습니다.