### PR TITLE
feat: 소비 분석 페이지를 실제 DB 데이터 기반으로 전환

### DIFF
--- a/src/main/java/com/intelliJ_JO/modam/domain/account/service/AccountService.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/account/service/AccountService.java
@@ -147,7 +147,7 @@ public class AccountService {
                 .collect(Collectors.toList());
     }
 
-    // 계좌 번호 생성 (1100-XXXXXXXX-XXX 형식, 중복 시 재생성)
+    // 계좌 번호 생성 (5050-XXXXXXXX-XXX 형식, 중복 시 재생성)
     private String generateAccountNumber() {
         Random rnd = new Random();
         String candidate;
@@ -155,7 +155,7 @@ public class AccountService {
             // 8자리 + 3자리 랜덤 숫자
             String mid   = String.format("%08d", rnd.nextInt(100_000_000));
             String check = String.format("%03d", rnd.nextInt(1_000));
-            candidate = "1100-" + mid + "-" + check;
+            candidate = "5050-" + mid + "-" + check;
         } while (accountRepository.existsByAccountNumber(candidate));
         return candidate;
     }

--- a/src/main/java/com/intelliJ_JO/modam/global/view/AnalysisViewController.java
+++ b/src/main/java/com/intelliJ_JO/modam/global/view/AnalysisViewController.java
@@ -1,21 +1,46 @@
 package com.intelliJ_JO.modam.global.view;
 
 import com.intelliJ_JO.modam.config.security.CustomUserDetails;
+import com.intelliJ_JO.modam.domain.account.entity.Account;
+import com.intelliJ_JO.modam.domain.account.repository.AccountMemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
 
 @Controller
 @RequiredArgsConstructor
 public class AnalysisViewController {
 
     private final DashboardService dashboardService;
+    private final AccountMemberRepository accountMemberRepository;
 
     @GetMapping({"/analysis", "/spending-analysis"})
-    public String spendingAnalysis(@AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
+    public String spendingAnalysis(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                   @RequestParam(required = false) String month,
+                                   Model model) {
         dashboardService.populateHeader(userDetails.getMember(), model);
+
+        Long memberId = userDetails.getMember().getId();
+        Account account = accountMemberRepository
+                .findFirstByMemberId(memberId)
+                .map(am -> am.getAccount())
+                .orElse(null);
+
+        Long accountId = account != null ? account.getId() : null;
+
+        String selectedMonth = (month != null && !month.isBlank())
+                ? month
+                : YearMonth.now().format(DateTimeFormatter.ofPattern("yyyy-MM"));
+
+        model.addAttribute("accountId", accountId);
+        model.addAttribute("selectedMonth", selectedMonth);
+
         return "domain/analysis/spending-analysis";
     }
 }

--- a/src/main/resources/templates/domain/analysis/spending-analysis.html
+++ b/src/main/resources/templates/domain/analysis/spending-analysis.html
@@ -37,15 +37,10 @@
           </button>
         </div>
 
-        <!-- 월 선택 -->
+        <!-- 월 선택 (JS로 동적 생성) -->
         <div class="relative">
           <select id="monthSelect" onchange="selectMonth(this.value)"
                   class="appearance-none bg-white border border-gray-200 rounded-2xl px-6 py-3 pr-12 text-gray-900 font-medium cursor-pointer hover:bg-gray-50 transition-colors text-lg">
-            <option value="2026-05">2026년 5월</option>
-            <option value="2026-04">2026년 4월</option>
-            <option value="2026-03">2026년 3월</option>
-            <option value="2026-02">2026년 2월</option>
-            <option value="2026-01">2026년 1월</option>
           </select>
           <i data-lucide="calendar" class="absolute right-4 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400 pointer-events-none"></i>
         </div>
@@ -61,7 +56,7 @@
               <i data-lucide="dollar-sign" class="w-5 h-5 text-[#F5A5A5]"></i>
             </div>
           </div>
-          <div id="totalSpending" class="text-3xl font-bold text-gray-900">₩1,245,000</div>
+          <div id="totalSpending" class="text-3xl font-bold text-gray-900">₩0</div>
         </div>
 
         <!-- 일 평균 소비 -->
@@ -72,7 +67,7 @@
               <i data-lucide="trending-up" class="w-5 h-5 text-[#A5C9E8]"></i>
             </div>
           </div>
-          <div id="avgSpending" class="text-3xl font-bold text-gray-900">₩41,500</div>
+          <div id="avgSpending" class="text-3xl font-bold text-gray-900">₩0</div>
           <div class="text-xs text-gray-600 mt-1">일 평균</div>
         </div>
 
@@ -84,20 +79,20 @@
               <i data-lucide="pie-chart" class="w-5 h-5 text-[#FFDAB9]"></i>
             </div>
           </div>
-          <div id="topCategoryName" class="text-2xl font-bold text-gray-900 mb-1">식비</div>
-          <div id="topCategoryAmount" class="text-sm text-gray-600">₩450,000</div>
+          <div id="topCategoryName" class="text-2xl font-bold text-gray-900 mb-1">-</div>
+          <div id="topCategoryAmount" class="text-sm text-gray-600">₩0</div>
         </div>
 
         <!-- 전월 대비 -->
-        <div id="changeCard" class="bg-gradient-to-br from-[#FFEBEE] to-[#FFCDD2] rounded-3xl p-6 shadow-sm">
+        <div id="changeCard" class="bg-gradient-to-br from-[#F3F4F6] to-[#E5E7EB] rounded-3xl p-6 shadow-sm">
           <div class="flex items-center justify-between mb-3">
             <span class="text-sm text-gray-600 font-medium">전월 대비</span>
             <div class="w-10 h-10 bg-white/80 rounded-xl flex items-center justify-center">
-              <i id="changeIcon" data-lucide="trending-up" class="w-5 h-5 text-red-500"></i>
+              <i id="changeIcon" data-lucide="minus" class="w-5 h-5 text-gray-500"></i>
             </div>
           </div>
-          <div id="changeRate" class="text-3xl font-bold text-red-600">+18.6%</div>
-          <div id="changeLabel" class="text-xs text-gray-600 mt-1">증가</div>
+          <div id="changeRate" class="text-3xl font-bold text-gray-600">0.0%</div>
+          <div id="changeLabel" class="text-xs text-gray-600 mt-1">동일</div>
         </div>
       </div>
 
@@ -143,117 +138,91 @@
   <th:block th:replace="~{common/layout/footer :: footer}"></th:block>
 
   <script th:inline="javascript">
-    /* ===== 서버 데이터 (Spring Boot 연동 시 th:inline="javascript"로 주입) ===== */
-    const serverMonth    = /*[[${selectedMonth}]]*/ '2026-05';
-    const serverData     = /*[[${analysisData}]]*/ null;
+    /* ===== 서버에서 주입된 값 ===== */
+    const accountId   = /*[[${accountId}]]*/ null;
+    const serverMonth = /*[[${selectedMonth}]]*/ null;
 
-    /* ===== 전체 월별 데이터 (클라이언트 폴백) ===== */
-    const allMonthData = {
-      '2026-05': {
-        categories: [
-          { name: '식비',   value: 450000, color: '#F5A5A5' },
-          { name: '데이트', value: 320000, color: '#A5C9E8' },
-          { name: '생활비', value: 275000, color: '#FFDAB9' },
-          { name: '교통비', value: 120000, color: '#B8E6B8' },
-          { name: '기타',   value:  80000, color: '#D8BFD8' }
-        ],
-        previousTotal: 1050000,
-        insights: [
-          { emoji: '💕', title: '이번 달은 데이트 비용이 지난달보다 18% 증가했어요', desc: '함께하는 시간이 많아졌네요! 특별한 날이 있으셨나요?' },
-          { emoji: '🍽️', title: '식비 소비가 전체의 42%를 차지하고 있어요', desc: '외식 빈도가 높은 편이에요. 주 1-2회 집밥 요리로 월 10만원 절약 가능해요!' }
-        ]
-      },
-      '2026-04': {
-        categories: [
-          { name: '식비',   value: 380000, color: '#F5A5A5' },
-          { name: '데이트', value: 270000, color: '#A5C9E8' },
-          { name: '생활비', value: 220000, color: '#FFDAB9' },
-          { name: '교통비', value: 110000, color: '#B8E6B8' },
-          { name: '기타',   value:  70000, color: '#D8BFD8' }
-        ],
-        previousTotal: 780000,
-        insights: [
-          { emoji: '🎬', title: '이번 달은 문화생활 비용이 증가했어요', desc: '영화, 공연 관람이 많았네요. 즐거운 한 달 보내셨나요?' },
-          { emoji: '💰', title: '지난달보다 27만원을 더 사용했어요', desc: '계획적인 소비를 위해 예산을 설정해보는 건 어떨까요?' }
-        ]
-      },
-      '2026-03': {
-        categories: [
-          { name: '식비',   value: 320000, color: '#F5A5A5' },
-          { name: '생활비', value: 210000, color: '#FFDAB9' },
-          { name: '데이트', value: 150000, color: '#A5C9E8' },
-          { name: '교통비', value:  70000, color: '#B8E6B8' },
-          { name: '기타',   value:  30000, color: '#D8BFD8' }
-        ],
-        previousTotal: 920000,
-        insights: [
-          { emoji: '👏', title: '지난달보다 14만원 절약했어요!', desc: '훌륭한 소비 습관이에요. 이 페이스를 유지해보세요!' },
-          { emoji: '🏠', title: '생활비 지출이 안정적이에요', desc: '필수 지출을 잘 관리하고 계시네요.' }
-        ]
-      },
-      '2026-02': {
-        categories: [
-          { name: '식비',   value: 420000, color: '#F5A5A5' },
-          { name: '데이트', value: 280000, color: '#A5C9E8' },
-          { name: '생활비', value: 120000, color: '#FFDAB9' },
-          { name: '교통비', value:  60000, color: '#B8E6B8' },
-          { name: '기타',   value:  40000, color: '#D8BFD8' }
-        ],
-        previousTotal: 850000,
-        insights: [
-          { emoji: '💝', title: '발렌타인데이가 있었던 2월이네요!', desc: '데이트 비용이 평소보다 높았어요. 특별한 추억 만드셨나요?' },
-          { emoji: '📈', title: '전월 대비 7만원 증가했어요', desc: '특별한 날이 많은 달이었네요.' }
-        ]
-      },
-      '2026-01': {
-        categories: [
-          { name: '식비',   value: 350000, color: '#F5A5A5' },
-          { name: '생활비', value: 250000, color: '#FFDAB9' },
-          { name: '데이트', value: 150000, color: '#A5C9E8' },
-          { name: '교통비', value:  70000, color: '#B8E6B8' },
-          { name: '기타',   value:  30000, color: '#D8BFD8' }
-        ],
-        previousTotal: 0,
-        insights: [
-          { emoji: '🎉', title: '모담 사용을 시작하신 첫 달이에요!', desc: '함께 시작하는 금융 관리, 앞으로가 기대되네요!' },
-          { emoji: '✨', title: '새해를 함께 시작하셨네요', desc: '올 한해도 건강한 소비 습관을 만들어가요!' }
-        ]
-      }
-    };
+    /* ===== 카테고리 색상 팔레트 ===== */
+    const CATEGORY_COLORS = ['#F5A5A5','#A5C9E8','#FFDAB9','#B8E6B8','#D8BFD8','#DDA0DD','#F0E68C'];
 
-    /* 월별 추이 데이터 (고정) */
-    const trendData = [
-      { month: '1월', amount: 850000 },
-      { month: '2월', amount: 920000 },
-      { month: '3월', amount: 780000 },
-      { month: '4월', amount: 1050000 },
-      { month: '5월', amount: 1245000 }
-    ];
+    /* ===== 이번달 / 지난달 문자열 동적 계산 ===== */
+    const now = new Date();
+    const thisMonthStr = now.getFullYear() + '-' + String(now.getMonth() + 1).padStart(2, '0');
+    const lastMonthDate = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+    const lastMonthStr = lastMonthDate.getFullYear() + '-' + String(lastMonthDate.getMonth() + 1).padStart(2, '0');
 
     /* ===== 상태 ===== */
-    let currentMonth = serverMonth || '2026-05';
+    let currentMonth = serverMonth || thisMonthStr;
     let lineChartInst = null;
     let donutChartInst = null;
 
+    /* ===== 월 선택 드롭다운 동적 생성 (최근 12개월) ===== */
+    function buildMonthOptions() {
+      const select = document.getElementById('monthSelect');
+      select.innerHTML = '';
+      for (let i = 0; i < 12; i++) {
+        const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+        const val = d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0');
+        const label = d.getFullYear() + '년 ' + (d.getMonth() + 1) + '월';
+        const opt = document.createElement('option');
+        opt.value = val;
+        opt.textContent = label;
+        select.appendChild(opt);
+      }
+      select.value = currentMonth;
+    }
+
+    /* ===== yyyy-MM 파싱 ===== */
+    function parseYM(ymStr) {
+      const [year, month] = ymStr.split('-').map(Number);
+      return { year, month };
+    }
+
+    /* ===== API 호출 ===== */
+    async function fetchSummary(month) {
+      if (!accountId) return null;
+      try {
+        const { year, month: m } = parseYM(month);
+        const res = await fetch(`/api/analysis/${accountId}/summary?year=${year}&month=${m}`);
+        if (!res.ok) return null;
+        const json = await res.json();
+        return json.data || null;
+      } catch (e) {
+        return null;
+      }
+    }
+
+    async function fetchTrend(month) {
+      if (!accountId) return null;
+      try {
+        const { year, month: m } = parseYM(month);
+        const res = await fetch(`/api/analysis/${accountId}/monthly-trend?year=${year}&month=${m}`);
+        if (!res.ok) return null;
+        const json = await res.json();
+        return json.data || null;
+      } catch (e) {
+        return null;
+      }
+    }
+
     /* ===== 탭 선택 ===== */
     function selectPeriod(period) {
-      const map = { '이번달': '2026-05', '지난달': '2026-04' };
-      currentMonth = map[period];
+      currentMonth = period === '이번달' ? thisMonthStr : lastMonthStr;
       document.getElementById('monthSelect').value = currentMonth;
       setTabActive(period);
-      renderAll();
+      Promise.all([renderAll(), renderLineChart()]);
     }
 
     function selectMonth(month) {
       currentMonth = month;
-      /* 이번달/지난달 탭 비활성화 */
-      setTabActive(null);
-      renderAll();
+      if (month === thisMonthStr) setTabActive('이번달');
+      else if (month === lastMonthStr) setTabActive('지난달');
+      else setTabActive(null);
+      Promise.all([renderAll(), renderLineChart()]);
     }
 
     function setTabActive(period) {
-      const tabs = ['이번달', '지난달'];
-      tabs.forEach(t => {
+      ['이번달', '지난달'].forEach(t => {
         const btn = document.getElementById('tab' + t);
         if (t === period) {
           btn.className = 'px-8 py-3 rounded-2xl transition-all text-lg font-medium bg-[#F5A5A5] text-white shadow-md';
@@ -263,67 +232,92 @@
       });
     }
 
-    /* ===== 화면 전체 갱신 ===== */
-    function renderAll() {
-      /* 서버 데이터 우선, 없으면 클라이언트 폴백 */
-      const data = (serverData && serverData[currentMonth]) || allMonthData[currentMonth];
-      if (!data) return;
+    /* ===== 요약 카드 + 도넛 + 인사이트 갱신 ===== */
+    async function renderAll() {
+      const summary = await fetchSummary(currentMonth);
 
-      const categories   = data.categories;
-      const totalSpending = categories.reduce((s, c) => s + c.value, 0);
-      const avgSpending   = Math.round(totalSpending / 30);
-      const topCat        = categories[0];
-      const prevTotal     = data.previousTotal;
-      const changeRate    = prevTotal > 0
-        ? ((totalSpending - prevTotal) / prevTotal * 100).toFixed(1)
-        : '0.0';
-      const isIncrease    = totalSpending > prevTotal;
+      if (!summary) {
+        document.getElementById('totalSpending').textContent = '₩0';
+        document.getElementById('avgSpending').textContent = '₩0';
+        document.getElementById('topCategoryName').textContent = '-';
+        document.getElementById('topCategoryAmount').textContent = '₩0';
+        renderChangeCard('동일', 0);
+        renderDonut([], 0);
+        renderInsights([]);
+        return;
+      }
 
-      /* 요약 카드 */
-      document.getElementById('totalSpending').textContent   = '₩' + totalSpending.toLocaleString();
-      document.getElementById('avgSpending').textContent     = '₩' + avgSpending.toLocaleString();
-      document.getElementById('topCategoryName').textContent = topCat.name;
-      document.getElementById('topCategoryAmount').textContent = '₩' + topCat.value.toLocaleString();
+      document.getElementById('totalSpending').textContent = '₩' + summary.totalSpend.toLocaleString();
+      document.getElementById('avgSpending').textContent = '₩' + summary.dailyAvgSpend.toLocaleString();
+      document.getElementById('topCategoryName').textContent = summary.topCategory || '-';
+      document.getElementById('topCategoryAmount').textContent = '₩' + (summary.topCategoryAmount || 0).toLocaleString();
 
-      const changeCard  = document.getElementById('changeCard');
-      const changeIcon  = document.getElementById('changeIcon');
+      renderChangeCard(summary.prevMonthChangeDirection, summary.prevMonthChangeRate);
+
+      const categories = (summary.categoryBreakdowns || []).map((c, i) => ({
+        name: c.category,
+        value: c.amount,
+        color: CATEGORY_COLORS[i % CATEGORY_COLORS.length]
+      }));
+      renderDonut(categories, summary.totalSpend);
+
+      const insights = (summary.insights || []).map(ins => ({
+        emoji: ins.icon,
+        title: ins.title,
+        desc: ins.description
+      }));
+      renderInsights(insights);
+    }
+
+    /* ===== 전월 대비 카드 ===== */
+    function renderChangeCard(direction, rate) {
+      const changeCard   = document.getElementById('changeCard');
+      const changeIcon   = document.getElementById('changeIcon');
       const changeRateEl = document.getElementById('changeRate');
       const changeLabelEl = document.getElementById('changeLabel');
 
-      if (isIncrease) {
+      if (direction === '증가') {
         changeCard.className = 'bg-gradient-to-br from-[#FFEBEE] to-[#FFCDD2] rounded-3xl p-6 shadow-sm';
         changeIcon.setAttribute('data-lucide', 'trending-up');
         changeIcon.className = 'w-5 h-5 text-red-500';
         changeRateEl.className = 'text-3xl font-bold text-red-600';
-        changeRateEl.textContent = '+' + changeRate + '%';
+        changeRateEl.textContent = '+' + rate + '%';
         changeLabelEl.textContent = '증가';
-      } else {
+      } else if (direction === '감소') {
         changeCard.className = 'bg-gradient-to-br from-[#E8F5E9] to-[#C8E6C9] rounded-3xl p-6 shadow-sm';
         changeIcon.setAttribute('data-lucide', 'trending-down');
         changeIcon.className = 'w-5 h-5 text-green-500';
         changeRateEl.className = 'text-3xl font-bold text-green-600';
-        changeRateEl.textContent = changeRate + '%';
+        changeRateEl.textContent = '-' + rate + '%';
         changeLabelEl.textContent = '감소';
+      } else {
+        changeCard.className = 'bg-gradient-to-br from-[#F3F4F6] to-[#E5E7EB] rounded-3xl p-6 shadow-sm';
+        changeIcon.setAttribute('data-lucide', 'minus');
+        changeIcon.className = 'w-5 h-5 text-gray-500';
+        changeRateEl.className = 'text-3xl font-bold text-gray-600';
+        changeRateEl.textContent = '0.0%';
+        changeLabelEl.textContent = '동일';
       }
       lucide.createIcons();
-
-      /* 도넛 차트 */
-      renderDonut(categories, totalSpending);
-
-      /* AI 인사이트 */
-      renderInsights(data.insights);
     }
 
-    /* ===== 라인 차트 (최초 1회 렌더) ===== */
-    function renderLineChart() {
+    /* ===== 라인 차트 (선택 월 기준 최근 6개월) ===== */
+    async function renderLineChart() {
+      const trendData = await fetchTrend(currentMonth);
       const ctx = document.getElementById('lineChart').getContext('2d');
+
+      const labels  = trendData ? trendData.trends.map(d => d.label) : [];
+      const amounts = trendData ? trendData.trends.map(d => d.totalAmount) : [];
+
+      if (lineChartInst) lineChartInst.destroy();
+
       lineChartInst = new Chart(ctx, {
         type: 'line',
         data: {
-          labels: trendData.map(d => d.month),
+          labels,
           datasets: [{
             label: '소비',
-            data: trendData.map(d => d.amount),
+            data: amounts,
             borderColor: '#F5A5A5',
             backgroundColor: 'rgba(245,165,165,0.08)',
             borderWidth: 3,
@@ -363,7 +357,6 @@
     /* ===== 도넛 차트 ===== */
     function renderDonut(categories, total) {
       const ctx = document.getElementById('donutChart').getContext('2d');
-
       if (donutChartInst) donutChartInst.destroy();
 
       donutChartInst = new Chart(ctx, {
@@ -393,8 +386,11 @@
         }
       });
 
-      /* 범례 */
       const legend = document.getElementById('donutLegend');
+      if (categories.length === 0) {
+        legend.innerHTML = '<p class="text-gray-500 text-sm">소비 내역이 없습니다</p>';
+        return;
+      }
       legend.innerHTML = categories.map(c => `
         <div class="flex items-center justify-between">
           <div class="flex items-center gap-2">
@@ -403,7 +399,7 @@
           </div>
           <div class="text-right">
             <div class="text-sm font-semibold text-gray-900">₩${c.value.toLocaleString()}</div>
-            <div class="text-xs text-gray-500">${((c.value / total) * 100).toFixed(0)}%</div>
+            <div class="text-xs text-gray-500">${total > 0 ? ((c.value / total) * 100).toFixed(0) : 0}%</div>
           </div>
         </div>
       `).join('');
@@ -411,7 +407,12 @@
 
     /* ===== AI 인사이트 ===== */
     function renderInsights(insights) {
-      document.getElementById('insightList').innerHTML = insights.map(ins => `
+      const el = document.getElementById('insightList');
+      if (!insights || insights.length === 0) {
+        el.innerHTML = '<p class="text-gray-600">이번 달 소비 데이터가 없어요. 소비 내역이 쌓이면 인사이트를 확인할 수 있어요!</p>';
+        return;
+      }
+      el.innerHTML = insights.map(ins => `
         <p class="text-gray-800 leading-relaxed">
           ${ins.emoji} <strong>${ins.title}</strong><br>
           <span class="text-sm text-gray-700">${ins.desc}</span>
@@ -420,15 +421,13 @@
     }
 
     /* ===== 초기 렌더 ===== */
-    window.addEventListener('DOMContentLoaded', () => {
+    window.addEventListener('DOMContentLoaded', async () => {
       lucide.createIcons();
-      renderLineChart();
-      /* 초기 탭 상태 맞추기 */
-      if (currentMonth === '2026-05') setTabActive('이번달');
-      else if (currentMonth === '2026-04') setTabActive('지난달');
+      buildMonthOptions();
+      if (currentMonth === thisMonthStr) setTabActive('이번달');
+      else if (currentMonth === lastMonthStr) setTabActive('지난달');
       else setTabActive(null);
-      document.getElementById('monthSelect').value = currentMonth;
-      renderAll();
+      await Promise.all([renderAll(), renderLineChart()]);
     });
   </script>
   <th:block th:replace="~{common/layout/header :: scripts}"></th:block>


### PR DESCRIPTION
- AnalysisViewController에서 로그인 사용자의 accountId와 selectedMonth를 모델에 주입
- spending-analysis.html의 하드코딩 데이터를 제거하고 /api/analysis/{accountId}/summary, /api/analysis/{accountId}/monthly-trend API fetch로 교체
- 월 드롭다운을 현재 날짜 기준 최근 12개월로 동적 생성
- "이번달"/"지난달" 탭을 실제 현재 날짜 기준으로 동적 계산
- 계좌번호 앞자리 1100 → 5050 변경