### PR TITLE
feat: 회원가입 step2 비밀번호 UX 강화 및 step3 계좌번호 중복 확인 추가

### DIFF
--- a/src/main/java/com/intelliJ_JO/modam/domain/member/controller/MemberController.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/member/controller/MemberController.java
@@ -52,6 +52,12 @@ public class MemberController {
         return GlobalResponse.ok(memberService.checkUserIdAvailable(userId));
     }
 
+    @Operation(summary = "계좌번호 중복 확인 (true = 사용 가능)")
+    @GetMapping("/check-account")
+    public GlobalResponse<Boolean> checkAccountDuplicate(@RequestParam String accountNumber) {
+        return GlobalResponse.ok(memberService.checkAccountAvailable(accountNumber));
+    }
+
     @Operation(summary = "회원 탈퇴")
     @DeleteMapping("/{memberId}")
     public GlobalResponse<String> deleteMember(@PathVariable Long memberId) {

--- a/src/main/java/com/intelliJ_JO/modam/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/member/repository/MemberRepository.java
@@ -12,4 +12,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByUserId(String userId);
     boolean existsByEmail(String email);
     boolean existsByPhoneNo(String phoneNo);
+    boolean existsByPersAcctNo(String persAcctNo);
 }

--- a/src/main/java/com/intelliJ_JO/modam/domain/member/service/MemberService.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/member/service/MemberService.java
@@ -164,6 +164,10 @@ public class MemberService {
         return !memberRepository.existsByUserId(userId);
     }
 
+    public boolean checkAccountAvailable(String accountNumber) {
+        return !memberRepository.existsByPersAcctNo(accountNumber);
+    }
+
     // ====================================================================
     // 조장님 작업분 (아이디/비밀번호 찾기) 유지
     // ====================================================================

--- a/src/main/resources/templates/domain/auth/signup-step2.html
+++ b/src/main/resources/templates/domain/auth/signup-step2.html
@@ -100,12 +100,35 @@
           <!-- 비밀번호 -->
           <div>
             <label class="block text-gray-800 mb-2">비밀번호 <span class="text-red-500">*</span></label>
-            <input type="password" th:field="*{password}"
-                   class="w-full px-5 py-4 border-2 border-gray-200 rounded-2xl focus:border-[#FCE8E3] focus:outline-none transition-colors"
-                   placeholder="영문, 숫자, 특수문자 조합 8-20자"
-                   minlength="8" maxlength="20"
-                   oninput="checkPasswordMatch(); updateCharCount(this, 'pwCount', 8, 20)"/>
-            <div class="flex justify-between items-start mt-1">
+            <div class="relative">
+              <input type="password" th:field="*{password}"
+                     class="w-full px-5 py-4 pr-14 border-2 border-gray-200 rounded-2xl focus:border-[#FCE8E3] focus:outline-none transition-colors"
+                     placeholder="영문 대/소문자, 숫자, 특수문자 조합 8-20자"
+                     minlength="8" maxlength="20"
+                     oninput="checkPasswordStrength(this.value); checkPasswordMatch(); updateCharCount(this, 'pwCount', 8, 20)"/>
+              <button type="button" onclick="togglePassword('password', 'eyeIcon1')"
+                      class="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors">
+                <i id="eyeIcon1" data-lucide="eye" class="w-5 h-5"></i>
+              </button>
+            </div>
+            <!-- 비밀번호 강도 표시 -->
+            <div class="mt-2">
+              <div class="flex gap-1.5 mb-1">
+                <div id="strengthBar1" class="h-1.5 flex-1 rounded-full bg-gray-200 transition-all duration-300"></div>
+                <div id="strengthBar2" class="h-1.5 flex-1 rounded-full bg-gray-200 transition-all duration-300"></div>
+                <div id="strengthBar3" class="h-1.5 flex-1 rounded-full bg-gray-200 transition-all duration-300"></div>
+              </div>
+              <p id="strengthText" class="text-xs text-gray-400 h-4"></p>
+            </div>
+            <!-- 비밀번호 요구사항 체크리스트 -->
+            <ul class="mt-2 space-y-1">
+              <li id="req-len"     class="flex items-center gap-1.5 text-xs text-gray-400 transition-colors"><span class="req-icon font-bold">○</span> 8자 이상 20자 이하</li>
+              <li id="req-upper"   class="flex items-center gap-1.5 text-xs text-gray-400 transition-colors"><span class="req-icon font-bold">○</span> 영문 대문자 포함 (A-Z)</li>
+              <li id="req-lower"   class="flex items-center gap-1.5 text-xs text-gray-400 transition-colors"><span class="req-icon font-bold">○</span> 영문 소문자 포함 (a-z)</li>
+              <li id="req-num"     class="flex items-center gap-1.5 text-xs text-gray-400 transition-colors"><span class="req-icon font-bold">○</span> 숫자 포함 (0-9)</li>
+              <li id="req-special" class="flex items-center gap-1.5 text-xs text-gray-400 transition-colors"><span class="req-icon font-bold">○</span> 특수문자 포함 (!@#$%^&amp;* 등)</li>
+            </ul>
+            <div class="flex justify-between items-start mt-2">
               <p id="passwordError" class="hidden text-sm text-red-500"></p>
               <p class="text-xs text-gray-400 ml-auto shrink-0">최소 8자 · 최대 20자 · <span id="pwCount">0</span>/20</p>
             </div>
@@ -114,11 +137,17 @@
           <!-- 비밀번호 확인 -->
           <div>
             <label class="block text-gray-800 mb-2">비밀번호 확인 <span class="text-red-500">*</span></label>
-            <input type="password" th:field="*{passwordConfirm}"
-                   class="w-full px-5 py-4 border-2 border-gray-200 rounded-2xl focus:outline-none transition-colors"
-                   placeholder="비밀번호를 다시 입력해주세요"
-                   maxlength="20"
-                   oninput="checkPasswordMatch()"/>
+            <div class="relative">
+              <input type="password" th:field="*{passwordConfirm}"
+                     class="w-full px-5 py-4 pr-14 border-2 border-gray-200 rounded-2xl focus:outline-none transition-colors"
+                     placeholder="비밀번호를 다시 입력해주세요"
+                     maxlength="20"
+                     oninput="checkPasswordMatch()"/>
+              <button type="button" onclick="togglePassword('passwordConfirm', 'eyeIcon2')"
+                      class="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors">
+                <i id="eyeIcon2" data-lucide="eye" class="w-5 h-5"></i>
+              </button>
+            </div>
             <p id="pwMatchError" class="hidden text-sm text-red-500 mt-1">비밀번호가 일치하지 않습니다.</p>
             <p id="pwMatchSuccess" class="hidden text-sm text-green-500 mt-1">비밀번호가 일치합니다.</p>
           </div>
@@ -336,11 +365,18 @@
 
       // 비밀번호
       const password = document.getElementById('password').value;
+      const pwHasUpper   = /[A-Z]/.test(password);
+      const pwHasLower   = /[a-z]/.test(password);
+      const pwHasNum     = /[0-9]/.test(password);
+      const pwHasSpecial = /[!@#$%^&*()\-_=+\[\]{};:'",.<>/?\\|`~]/.test(password);
       if (!password) {
         showError('passwordError', '비밀번호를 입력해주세요.');
         valid = false;
       } else if (password.length < 8) {
         showError('passwordError', '비밀번호는 8자 이상이어야 합니다.');
+        valid = false;
+      } else if (!pwHasUpper || !pwHasLower || !pwHasNum || !pwHasSpecial) {
+        showError('passwordError', '영문 대/소문자, 숫자, 특수문자를 모두 포함해야 합니다.');
         valid = false;
       } else {
         clearError('passwordError');
@@ -448,6 +484,84 @@
         if (firstError) firstError.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }
       return valid;
+    }
+
+    /* 비밀번호 보이기/숨기기 토글 */
+    function togglePassword(inputId, iconId) {
+      const input = document.getElementById(inputId);
+      const icon  = document.getElementById(iconId);
+      if (input.type === 'password') {
+        input.type = 'text';
+        icon.setAttribute('data-lucide', 'eye-off');
+      } else {
+        input.type = 'password';
+        icon.setAttribute('data-lucide', 'eye');
+      }
+      lucide.createIcons();
+    }
+
+    /* 요구사항 항목 상태 업데이트 */
+    function updateReq(id, met) {
+      const el   = document.getElementById(id);
+      if (!el) return;
+      const icon = el.querySelector('.req-icon');
+      if (met) {
+        el.classList.remove('text-gray-400');
+        el.classList.add('text-green-500');
+        icon.textContent = '✓';
+      } else {
+        el.classList.remove('text-green-500');
+        el.classList.add('text-gray-400');
+        icon.textContent = '○';
+      }
+    }
+
+    /* 비밀번호 강도 및 요구사항 체크 */
+    function checkPasswordStrength(pw) {
+      const hasLen     = pw.length >= 8 && pw.length <= 20;
+      const hasUpper   = /[A-Z]/.test(pw);
+      const hasLower   = /[a-z]/.test(pw);
+      const hasNum     = /[0-9]/.test(pw);
+      const hasSpecial = /[!@#$%^&*()\-_=+\[\]{};:'",.<>/?\\|`~]/.test(pw);
+
+      updateReq('req-len',     hasLen);
+      updateReq('req-upper',   hasUpper);
+      updateReq('req-lower',   hasLower);
+      updateReq('req-num',     hasNum);
+      updateReq('req-special', hasSpecial);
+
+      const score = [hasLen, hasUpper, hasLower, hasNum, hasSpecial].filter(Boolean).length;
+      const bar1  = document.getElementById('strengthBar1');
+      const bar2  = document.getElementById('strengthBar2');
+      const bar3  = document.getElementById('strengthBar3');
+      const text  = document.getElementById('strengthText');
+
+      const reset = 'h-1.5 flex-1 rounded-full bg-gray-200 transition-all duration-300';
+      if (!pw) {
+        [bar1, bar2, bar3].forEach(b => b.className = reset);
+        text.textContent = '';
+        return;
+      }
+
+      if (score <= 2) {
+        bar1.className = 'h-1.5 flex-1 rounded-full bg-red-400 transition-all duration-300';
+        bar2.className = reset;
+        bar3.className = reset;
+        text.textContent = '약함';
+        text.className = 'text-xs text-red-400 h-4';
+      } else if (score <= 4) {
+        bar1.className = 'h-1.5 flex-1 rounded-full bg-yellow-400 transition-all duration-300';
+        bar2.className = 'h-1.5 flex-1 rounded-full bg-yellow-400 transition-all duration-300';
+        bar3.className = reset;
+        text.textContent = '보통';
+        text.className = 'text-xs text-yellow-500 h-4';
+      } else {
+        bar1.className = 'h-1.5 flex-1 rounded-full bg-green-400 transition-all duration-300';
+        bar2.className = 'h-1.5 flex-1 rounded-full bg-green-400 transition-all duration-300';
+        bar3.className = 'h-1.5 flex-1 rounded-full bg-green-400 transition-all duration-300';
+        text.textContent = '강함';
+        text.className = 'text-xs text-green-500 h-4';
+      }
     }
 
     /* 비밀번호 일치 실시간 확인 */

--- a/src/main/resources/templates/domain/auth/signup-step3.html
+++ b/src/main/resources/templates/domain/auth/signup-step3.html
@@ -103,11 +103,20 @@
 
           <div>
             <label class="block text-gray-800 mb-2">계좌번호</label>
-            <input type="text" th:field="*{accountNumber}"
-                   class="w-full px-5 py-4 border-2 border-gray-200 rounded-2xl focus:border-[#FCE8E3] focus:outline-none transition-colors"
-                   placeholder="'-' 없이 숫자만 입력"
-                   oninput="this.value=this.value.replace(/[^0-9]/g,'')"/>
-            <p class="text-sm text-gray-500 mt-2">본인 명의의 계좌만 등록 가능합니다</p>
+            <div class="flex gap-2">
+              <input type="text" th:field="*{accountNumber}"
+                     class="flex-1 px-5 py-4 border-2 border-gray-200 rounded-2xl focus:border-[#FCE8E3] focus:outline-none transition-colors"
+                     placeholder="'-' 없이 숫자만 입력"
+                     oninput="this.value=this.value.replace(/[^0-9]/g,''); onAccountNumberChange()"/>
+              <button type="button" onclick="checkAccountNumber()"
+                      class="px-5 py-4 bg-gray-100 text-gray-700 rounded-2xl hover:bg-gray-200 transition-colors whitespace-nowrap text-sm font-medium">
+                중복 확인
+              </button>
+            </div>
+            <div class="mt-1">
+              <p id="accountError" class="hidden text-sm text-red-500"></p>
+              <p id="accountSuccess" class="hidden text-sm text-green-500"></p>
+            </div>
           </div>
         </div>
 
@@ -116,8 +125,8 @@
              class="flex-1 py-4 bg-gray-100 text-gray-700 rounded-2xl hover:bg-gray-200 transition-colors flex items-center justify-center gap-2">
             <i data-lucide="chevron-left" class="w-5 h-5"></i> 이전
           </a>
-          <button type="submit"
-                  class="flex-1 py-4 bg-[#FCE8E3] text-gray-800 rounded-2xl hover:bg-[#FBD5CE] transition-colors flex items-center justify-center gap-2">
+          <button type="submit" id="submitBtn" disabled
+                  class="flex-1 py-4 bg-gray-200 text-gray-400 rounded-2xl transition-colors flex items-center justify-center gap-2 cursor-not-allowed">
             다음 <i data-lucide="chevron-right" class="w-5 h-5"></i>
           </button>
         </div>
@@ -138,6 +147,96 @@
 
   <script>
     lucide.createIcons();
+
+    let accountChecked = false;
+
+    function onAccountNumberChange() {
+      accountChecked = false;
+      document.getElementById('accountSuccess').classList.add('hidden');
+      document.getElementById('accountError').classList.add('hidden');
+      setSubmitEnabled(false);
+    }
+
+    function setSubmitEnabled(enabled) {
+      const btn = document.getElementById('submitBtn');
+      if (enabled) {
+        btn.disabled = false;
+        btn.className = 'flex-1 py-4 bg-[#FCE8E3] text-gray-800 rounded-2xl hover:bg-[#FBD5CE] transition-colors flex items-center justify-center gap-2 cursor-pointer';
+      } else {
+        btn.disabled = true;
+        btn.className = 'flex-1 py-4 bg-gray-200 text-gray-400 rounded-2xl transition-colors flex items-center justify-center gap-2 cursor-not-allowed';
+      }
+    }
+
+    async function checkAccountNumber() {
+      const accountNumber = document.getElementById('accountNumber').value.trim();
+      const errorEl   = document.getElementById('accountError');
+      const successEl = document.getElementById('accountSuccess');
+
+      errorEl.classList.add('hidden');
+      successEl.classList.add('hidden');
+      accountChecked = false;
+
+      const bank = document.getElementById('selectedBank').value;
+      if (!bank) {
+        errorEl.textContent = '은행을 먼저 선택해주세요.';
+        errorEl.classList.remove('hidden');
+        return;
+      }
+      if (!accountNumber) {
+        errorEl.textContent = '계좌번호를 입력해주세요.';
+        errorEl.classList.remove('hidden');
+        return;
+      }
+      if (accountNumber.length < 10) {
+        errorEl.textContent = '계좌번호는 10자리 이상 입력해주세요.';
+        errorEl.classList.remove('hidden');
+        return;
+      }
+
+      try {
+        const res  = await fetch('/api/member/check-account?accountNumber=' + encodeURIComponent(accountNumber));
+        const json = await res.json();
+        if (json.data === true) {
+          accountChecked = true;
+          successEl.textContent = '등록 가능한 계좌번호입니다.';
+          successEl.classList.remove('hidden');
+          setSubmitEnabled(true);
+        } else {
+          errorEl.textContent = '이미 등록된 계좌번호입니다.';
+          errorEl.classList.remove('hidden');
+          setSubmitEnabled(false);
+        }
+      } catch (e) {
+        errorEl.textContent = '중복 확인 중 오류가 발생했습니다.';
+        errorEl.classList.remove('hidden');
+      }
+    }
+
+    function validateStep3(event) {
+      const bank          = document.getElementById('selectedBank').value;
+      const accountNumber = document.getElementById('accountNumber').value.trim();
+      const errorEl       = document.getElementById('accountError');
+      let valid = true;
+
+      if (!bank) {
+        alert('은행을 선택해주세요.');
+        valid = false;
+      }
+
+      if (!accountNumber) {
+        errorEl.textContent = '계좌번호를 입력해주세요.';
+        errorEl.classList.remove('hidden');
+        valid = false;
+      } else if (!accountChecked) {
+        errorEl.textContent = '계좌번호 중복 확인을 해주세요.';
+        errorEl.classList.remove('hidden');
+        valid = false;
+      }
+
+      if (!valid) event.preventDefault();
+      return valid;
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
- step2: 비밀번호 입력 필드에 보이기/숨기기 토글, 강도 표시 바(약함/보통/강함), 요구사항 체크리스트(대/소문자·숫자·특수문자) 실시간 표시 추가
- step2: 폼 제출 시 비밀번호 복잡도 검사 강화 (대/소문자·숫자·특수문자 모두 포함 필수)
- step3: 계좌번호 중복 확인 API(GET /api/member/check-account) 추가
- step3: 중복 확인 성공 전까지 다음 버튼 비활성화 처리