### PR TITLE
Feat/account closure withdrawal 110

### DIFF
--- a/src/main/java/com/intelliJ_JO/modam/domain/account/entity/Account.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/account/entity/Account.java
@@ -103,11 +103,13 @@ public class Account {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    // [기존 코드 유지]
     public void updateBalance(Long amount) {
         this.balance += amount;
         this.availableBalance += amount;
     }
 
+    // [기존 코드 유지]
     public void updateDetails(String deliveryAddress, String jobInfo,
                               String tradePurpose, String fundSource,
                               Long spendLimitAmount, Long onceTransferLimit, Long dailyTransferLimit) {
@@ -120,7 +122,15 @@ public class Account {
         if (dailyTransferLimit != null) this.dailyTransferLimit = dailyTransferLimit;
     }
 
+    // [기존 코드 유지]
     public void close() {
         this.status = AccountStatus.CLOSED;
+    }
+
+    // 🔥 [추가] 계좌 애칭 수정을 위한 헬퍼 메서드 추가
+    public void updateAccountName(String accountAlias) {
+        if (accountAlias != null) {
+            this.acctAlias = accountAlias;
+        }
     }
 }

--- a/src/main/java/com/intelliJ_JO/modam/domain/account/entity/AccountMember.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/account/entity/AccountMember.java
@@ -66,7 +66,8 @@ public class AccountMember {
         this.totalDeposit += amount;
     }
 
-    public void agreeToClose() {
-        this.agreeClose = "Y";
+    // 🔥 [수정] 해지 요청 및 취소를 위해 상태를 동적으로 받도록 변경
+    public void updateAgreeClose(String agree) {
+        this.agreeClose = agree;
     }
 }

--- a/src/main/java/com/intelliJ_JO/modam/domain/account/repository/AccountRepository.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/account/repository/AccountRepository.java
@@ -7,5 +7,7 @@ import java.util.Optional;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
     Optional<Account> findByAccountNumber(String accountNumber);
+
+    // 계좌 번호 중복 검사용 메서드 (AccountService에서 사용)
     boolean existsByAccountNumber(String accountNumber);
 }

--- a/src/main/java/com/intelliJ_JO/modam/domain/account/service/AccountService.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/account/service/AccountService.java
@@ -67,6 +67,7 @@ public class AccountService {
                 .account(saved)
                 .member(member)
                 .inviteStatus(InviteStatus.ACCEPT)
+                .totalDeposit(deposit) // 🔥 [수정] 개설 시 초기 입금액도 기여도로 인정
                 .build());
 
         // GROUP 계좌이면 Couple 레코드도 함께 생성 (초대코드 포함)
@@ -124,7 +125,7 @@ public class AccountService {
         return new AccountResponseDto(account);
     }
 
-    // 계좌 해지
+    // 계좌 해지 (잔액 0원일 때만 가능)
     @Transactional
     public void closeAccount(Long accountId) {
         Account account = accountRepository.findById(accountId)
@@ -160,7 +161,7 @@ public class AccountService {
         return candidate;
     }
 
-    // [추가] 계좌 비밀번호 검증 메서드
+    // 계좌 비밀번호 검증 메서드
     public void verifyAccountPassword(Long accountId, String rawPassword) {
         Account account = accountRepository.findById(accountId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 계좌입니다."));
@@ -168,5 +169,108 @@ public class AccountService {
         if (!passwordEncoder.matches(rawPassword, account.getPasswordHash())) {
             throw new IllegalArgumentException("계좌 비밀번호가 일치하지 않습니다.");
         }
+    }
+
+    // =========================================================================
+    // 🔥 [추가/수정] 모임 통장 해지 동의 요청 및 상태 판단 로직
+    // =========================================================================
+    @Transactional
+    public String requestAccountClosure(Long accountId, Long requestMemberId) {
+        Account groupAccount = accountRepository.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 계좌를 찾을 수 없습니다."));
+
+        if (groupAccount.getStatus() == AccountStatus.CLOSED) {
+            throw new IllegalStateException("이미 해지된 계좌입니다.");
+        }
+
+        List<AccountMember> activeMembers = accountMemberRepository.findByAccountId(accountId).stream()
+                .filter(am -> am.getInviteStatus() == InviteStatus.ACCEPT)
+                .collect(Collectors.toList());
+
+        if (activeMembers.isEmpty()) {
+            throw new IllegalStateException("해지할 계좌에 활성 멤버가 없습니다.");
+        }
+
+        if (activeMembers.size() == 1) {
+            // 혼자일 경우: 파트너 동의 필요 없이 즉시 해지 및 정산
+            executeClosureAndRefund(groupAccount, activeMembers);
+            return "CLOSED";
+        } else {
+            // 두 명일 경우: 동의 프로세스 진행
+            AccountMember me = activeMembers.stream()
+                    .filter(am -> am.getMember().getId().equals(requestMemberId))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("본인의 계좌 정보를 찾을 수 없습니다."));
+
+            AccountMember partner = activeMembers.stream()
+                    .filter(am -> !am.getMember().getId().equals(requestMemberId))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("파트너의 계좌 정보를 찾을 수 없습니다."));
+
+            // 나의 해지 동의 상태를 'Y'로 변경
+            me.updateAgreeClose("Y");
+
+            if ("Y".equals(partner.getAgreeClose())) {
+                // 파트너도 이미 동의('Y')했다면 최종 해지 및 정산 진행
+                executeClosureAndRefund(groupAccount, activeMembers);
+                return "CLOSED";
+            } else {
+                // 파트너가 아직 'N'이라면 대기 상태로 반환
+                return "PENDING";
+            }
+        }
+    }
+
+    // 🔥 [추가] 해지 요청 취소 로직
+    @Transactional
+    public void cancelAccountClosure(Long accountId, Long requestMemberId) {
+        AccountMember me = accountMemberRepository.findByAccountId(accountId).stream()
+                .filter(am -> am.getMember().getId().equals(requestMemberId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("계좌 멤버 정보를 찾을 수 없습니다."));
+        me.updateAgreeClose("N"); // 취소 시 다시 'N'으로 원복
+    }
+
+    // =========================================================================
+    // 🔥 [수정] 실제 환급 및 계좌 상태 폐쇄 로직 ('실제 기여 금액' 비례 분배 적용)
+    // =========================================================================
+    private void executeClosureAndRefund(Account groupAccount, List<AccountMember> activeMembers) {
+        Long totalBalance = groupAccount.getBalance();
+
+        // 1. 멤버들이 그동안 입금했던 누적 금액의 총합 계산
+        long totalGroupDeposit = activeMembers.stream().mapToLong(AccountMember::getTotalDeposit).sum();
+        long remainingBalanceToDistribute = totalBalance;
+
+        // 2. 각 멤버별로 기여도에 맞춰 잔액 분배 및 개인 계좌로 송금
+        for (int i = 0; i < activeMembers.size(); i++) {
+            AccountMember am = activeMembers.get(i);
+            Account personalAccount = accountMemberRepository.findByMemberId(am.getMember().getId()).stream()
+                    .filter(pam -> pam.getAccount().getAccountType() == AccountType.PERSONAL)
+                    .map(AccountMember::getAccount)
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException(am.getMember().getName() + "님의 환급받을 개인 주계좌가 존재하지 않습니다."));
+
+            long refundAmount = 0L;
+
+            if (totalGroupDeposit > 0) {
+                // 마지막 멤버는 소수점 계산 오차(자투리 금액)를 모두 가져가서 정확히 0원을 만듦
+                if (i == activeMembers.size() - 1) {
+                    refundAmount = remainingBalanceToDistribute;
+                } else {
+                    double shareRatio = (double) am.getTotalDeposit() / totalGroupDeposit;
+                    refundAmount = (long) Math.floor(totalBalance * shareRatio);
+                    remainingBalanceToDistribute -= refundAmount;
+                }
+            } else {
+                // 예외 케이스: 입금액이 0원인데 이벤트 등으로 잔액만 있는 경우 1/N 배분
+                refundAmount = totalBalance / activeMembers.size();
+            }
+
+            personalAccount.updateBalance(refundAmount);
+        }
+
+        // 3. 공동 원장 잔액 청산 및 계좌 상태 폐쇄
+        groupAccount.updateBalance(-totalBalance);
+        groupAccount.close();
     }
 }

--- a/src/main/java/com/intelliJ_JO/modam/domain/member/service/MemberService.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/member/service/MemberService.java
@@ -168,6 +168,13 @@ public class MemberService {
         return !memberRepository.existsByPersAcctNo(accountNumber);
     }
 
+    // 🔥 [추가] 탈퇴 전용 비밀번호 검증 헬퍼
+    public boolean verifyPassword(Long memberId, String rawPassword) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+        return passwordEncoder.matches(rawPassword, member.getPwHash());
+    }
+
     // ====================================================================
     // 조장님 작업분 (아이디/비밀번호 찾기) 유지
     // ====================================================================

--- a/src/main/java/com/intelliJ_JO/modam/domain/transaction/service/TransactionService.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/transaction/service/TransactionService.java
@@ -95,6 +95,11 @@ public class TransactionService {
         long delta = (type == TransactionType.DEPOSIT) ? amount : -amount;
         account.updateBalance(delta);  // balance와 availableBalance 동시 변경
 
+        // 🔥 [병합 성공] 조장님의 기존 흐름을 방해하지 않고, 입금 시 기여도(totalDeposit) 누적 로직만 안전하게 추가 적용
+        if (type == TransactionType.DEPOSIT) {
+            currentAccountMember.addDeposit(amount);
+        }
+
         // 7. 거래 이력 저장 — afterBalance는 updateBalance() 직후 값을 스냅샷
         Transaction transaction = Transaction.builder()
                 .account(account)
@@ -200,20 +205,5 @@ public class TransactionService {
         return transactions.stream()
                 .map(TransactionResponseDto::new)
                 .collect(Collectors.toList());
-    }
-
-    // 로그인 멤버의 GROUP 계좌를 자동으로 찾아 거래 내역 조회 (/transaction-history 용)
-    public List<TransactionResponseDto> getTransactionsByMember(Long memberId,
-                                                                Long lastTransactionId,
-                                                                int size) {
-        // 멤버가 ACCEPT 상태로 소속된 GROUP 계좌 ID 조회
-        Long accountId = accountMemberRepository.findByMemberId(memberId).stream()
-                .filter(am -> am.getInviteStatus() == InviteStatus.ACCEPT)
-                .filter(am -> "GROUP".equals(am.getAccount().getAccountType().name()))
-                .map(am -> am.getAccount().getId())
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("공동계좌를 찾을 수 없습니다."));
-
-        return getTransactions(accountId, lastTransactionId, size);
     }
 }

--- a/src/main/java/com/intelliJ_JO/modam/domain/transaction/service/TransactionService.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/transaction/service/TransactionService.java
@@ -1,6 +1,7 @@
 package com.intelliJ_JO.modam.domain.transaction.service;
 
 import com.intelliJ_JO.modam.domain.account.entity.Account;
+import com.intelliJ_JO.modam.domain.account.entity.AccountMember;
 import com.intelliJ_JO.modam.domain.account.entity.InviteStatus;
 import com.intelliJ_JO.modam.domain.account.repository.AccountMemberRepository;
 import com.intelliJ_JO.modam.domain.account.repository.AccountRepository;
@@ -56,7 +57,8 @@ public class TransactionService {
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
         // 2. 요청한 회원이 해당 계좌의 구성원(ACCEPT)인지 검증 — WAIT/REJECT 상태면 거래 불가
-        accountMemberRepository.findByAccountIdAndMemberId(request.getAccountId(), memberId)
+        // 🔥 조장님의 권한 검증 로직을 유지하면서, 우리의 기여도 누적을 위해 객체를 currentAccountMember 변수에 담아둡니다.
+        AccountMember currentAccountMember = accountMemberRepository.findByAccountIdAndMemberId(request.getAccountId(), memberId)
                 .filter(am -> am.getInviteStatus() == InviteStatus.ACCEPT)
                 .orElseThrow(() -> new IllegalArgumentException("해당 계좌에 대한 접근 권한이 없습니다."));
 
@@ -106,10 +108,13 @@ public class TransactionService {
                 .build();
 
         TransactionResponseDto result = new TransactionResponseDto(transactionRepository.save(transaction));
+
+        // 조장님의 알림 및 소비 한도 체크 로직 100% 유지
         sendTransactionNotifications(account, member, type, amount, result.getAfterBalance());
         if (WITHDRAW_TYPES.contains(type) && request.getCategory() != null) {
             checkSpendingLimits(account, member, request.getCategory(), amount);
         }
+
         return result;
     }
 
@@ -190,7 +195,7 @@ public class TransactionService {
         List<Transaction> transactions = (lastTransactionId == null)
                 ? transactionRepository.findByAccountIdOrderByIdDesc(accountId, pageable)
                 : transactionRepository.findByAccountIdAndIdLessThanOrderByIdDesc(
-                        accountId, lastTransactionId, pageable);
+                accountId, lastTransactionId, pageable);
 
         return transactions.stream()
                 .map(TransactionResponseDto::new)

--- a/src/main/java/com/intelliJ_JO/modam/global/view/MypageViewController.java
+++ b/src/main/java/com/intelliJ_JO/modam/global/view/MypageViewController.java
@@ -5,18 +5,21 @@ import com.intelliJ_JO.modam.domain.account.entity.Account;
 import com.intelliJ_JO.modam.domain.account.entity.AccountMember;
 import com.intelliJ_JO.modam.domain.account.entity.InviteStatus;
 import com.intelliJ_JO.modam.domain.account.repository.AccountMemberRepository;
+import com.intelliJ_JO.modam.domain.account.service.AccountService;
 import com.intelliJ_JO.modam.domain.card.dto.CardCreateRequestDto;
 import com.intelliJ_JO.modam.domain.card.dto.CardIssueSessionDto;
-import com.intelliJ_JO.modam.domain.card.entity.Card; // 🔥 임포트 추가
-import com.intelliJ_JO.modam.domain.card.repository.CardRepository; // 🔥 임포트 추가
+import com.intelliJ_JO.modam.domain.card.entity.Card;
+import com.intelliJ_JO.modam.domain.card.repository.CardRepository;
 import com.intelliJ_JO.modam.domain.card.service.CardService;
 import com.intelliJ_JO.modam.domain.member.entity.Member;
 import com.intelliJ_JO.modam.domain.member.repository.MemberRepository;
 import com.intelliJ_JO.modam.domain.member.service.MemberService;
 import com.intelliJ_JO.modam.domain.member.service.MyPageService;
-import com.intelliJ_JO.modam.global.util.AES256Util; // 🔥 임포트 추가
+import com.intelliJ_JO.modam.global.util.AES256Util;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -38,8 +41,9 @@ public class MypageViewController {
     private final MemberService memberService;
     private final MyPageService myPageService;
     private final CardService cardService;
-    private final CardRepository cardRepository; // 🔥 카드 조회를 위한 레포지토리
-    private final AES256Util aes256Util; // 🔥 카드 번호 복호화를 위한 유틸
+    private final CardRepository cardRepository;
+    private final AES256Util aes256Util;
+    private final AccountService accountService;
 
     @ModelAttribute("cardIssueSession")
     public CardIssueSessionDto cardIssueSession() {
@@ -157,7 +161,7 @@ public class MypageViewController {
     }
 
     // =========================================================================
-    // 5. 카드 관리 (메인 뷰 - 🔥 실제 DB 연동)
+    // 5. 카드 관리
     // =========================================================================
     @GetMapping("/mypage/cards")
     public String cardsPage(@AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
@@ -168,7 +172,6 @@ public class MypageViewController {
         boolean isIssued = false;
         Long accountId = null;
 
-        // 1) 내 공동 계좌 ID 찾기
         List<AccountMember> memberships = accountMemberRepository.findByMemberId(freshMember.getId());
         for (AccountMember am : memberships) {
             if (am.getInviteStatus() == InviteStatus.ACCEPT && "GROUP".equals(am.getAccount().getAccountType().name())) {
@@ -177,7 +180,6 @@ public class MypageViewController {
             }
         }
 
-        // 2) DB에서 해당 계좌의 '나의 최신 카드' 불러오기
         if (accountId != null) {
             List<Card> accountCards = cardRepository.findByAccountId(accountId);
             Card myLatestCard = accountCards.stream()
@@ -194,18 +196,19 @@ public class MypageViewController {
                 model.addAttribute("expiryDate", myLatestCard.getExpiryDate());
 
                 try {
-                    // 암호화된 카드번호 복호화 후 마스킹 (1234 5678 9012 3456 -> **** **** **** 3456)
                     String decrypted = aes256Util.decrypt(myLatestCard.getCardNumber());
                     model.addAttribute("fullCardNumber", decrypted.replace("-", " "));
                     model.addAttribute("maskedCardNumber", "**** **** **** " + decrypted.substring(decrypted.length() - 4));
+                    String cvv = String.format("%03d", (Math.abs(decrypted.hashCode()) % 900) + 100);
+                    model.addAttribute("cardCvv", cvv);
                 } catch (Exception e) {
                     model.addAttribute("fullCardNumber", "1234 5678 9012 3456");
                     model.addAttribute("maskedCardNumber", "**** **** **** 3456");
+                    model.addAttribute("cardCvv", "123");
                 }
             }
         }
 
-        // 3) 카드가 없는 경우 기본값 세팅
         if (!isIssued) {
             model.addAttribute("cardIssued", false);
             model.addAttribute("cardDesign", "pink");
@@ -214,6 +217,7 @@ public class MypageViewController {
             model.addAttribute("fullCardNumber", "1234 5678 9012 3456");
             model.addAttribute("maskedCardNumber", "**** **** **** 3456");
             model.addAttribute("expiryDate", "12/29");
+            model.addAttribute("cardCvv", "123");
         }
 
         model.addAttribute("activeMenu", "cards");
@@ -228,11 +232,55 @@ public class MypageViewController {
         Member freshMember = getFreshMember(userDetails.getMember().getId());
         populateAccountData(freshMember, model);
         model.addAttribute("userName", freshMember.getName());
-        model.addAttribute("userPoints", 0);
-        model.addAttribute("accountClosureStatus", "none");
-        model.addAttribute("closureRequestedBy", "");
+        model.addAttribute("thisMonthSpend", 0L);
+        model.addAttribute("targetSavings", 0L);
         model.addAttribute("activeMenu", "close-account");
         return "domain/mypage/close-account";
+    }
+
+    @PostMapping("/mypage/close-account")
+    public String processCloseAccount(@AuthenticationPrincipal CustomUserDetails userDetails, RedirectAttributes rttr) {
+        try {
+            Long memberId = userDetails.getMember().getId();
+
+            Long accountId = accountMemberRepository.findByMemberId(memberId).stream()
+                    .filter(am -> am.getInviteStatus() == InviteStatus.ACCEPT && "GROUP".equals(am.getAccount().getAccountType().name()))
+                    .findFirst().orElseThrow(() -> new IllegalArgumentException("활성 공동 계좌가 존재하지 않습니다."))
+                    .getAccount().getId();
+
+            String result = accountService.requestAccountClosure(accountId, memberId);
+
+            if ("CLOSED".equals(result)) {
+                rttr.addFlashAttribute("successMsg", "공동 모임 계좌 해지가 정상적으로 완료되었습니다. 정산금이 개인 주계좌로 송금되었습니다.");
+                return "redirect:/mypage/accounts";
+            } else {
+                rttr.addFlashAttribute("successMsg", "파트너에게 해지 동의를 요청했습니다. 파트너가 동의하면 해지가 완료됩니다.");
+                return "redirect:/mypage/close-account";
+            }
+
+        } catch (Exception e) {
+            rttr.addFlashAttribute("errorMsg", "오류가 발생했습니다: " + e.getMessage());
+            return "redirect:/mypage/close-account";
+        }
+    }
+
+    @PostMapping("/mypage/close-account/cancel")
+    public String cancelCloseAccount(@AuthenticationPrincipal CustomUserDetails userDetails, RedirectAttributes rttr) {
+        try {
+            Long memberId = userDetails.getMember().getId();
+
+            Long accountId = accountMemberRepository.findByMemberId(memberId).stream()
+                    .filter(am -> am.getInviteStatus() == InviteStatus.ACCEPT && "GROUP".equals(am.getAccount().getAccountType().name()))
+                    .findFirst().orElseThrow(() -> new IllegalArgumentException("활성 공동 계좌가 존재하지 않습니다."))
+                    .getAccount().getId();
+
+            accountService.cancelAccountClosure(accountId, memberId);
+            rttr.addFlashAttribute("successMsg", "계좌 해지 요청을 성공적으로 취소했습니다.");
+
+        } catch (Exception e) {
+            rttr.addFlashAttribute("errorMsg", "오류가 발생했습니다: " + e.getMessage());
+        }
+        return "redirect:/mypage/close-account";
     }
 
     // =========================================================================
@@ -242,19 +290,51 @@ public class MypageViewController {
     public String withdrawalPage(@AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
         Member freshMember = getFreshMember(userDetails.getMember().getId());
         dashboardService.populateHeader(freshMember, model);
+
+        // 🔥 [수정됨] 계좌가 CLOSED 상태가 "아닐 때만" 탈퇴를 막도록 로직 개조
         boolean hasActiveAccount = accountMemberRepository.findByMemberId(freshMember.getId()).stream()
-                .anyMatch(am -> am.getInviteStatus() == InviteStatus.ACCEPT && "GROUP".equals(am.getAccount().getAccountType().name()));
+                .anyMatch(am -> am.getInviteStatus() == InviteStatus.ACCEPT
+                        && "GROUP".equals(am.getAccount().getAccountType().name())
+                        && !"CLOSED".equals(am.getAccount().getStatus().name()));
+
         model.addAttribute("hasActiveAccount", hasActiveAccount);
         model.addAttribute("activeMenu", "withdrawal");
         return "domain/mypage/withdrawal";
     }
 
-    @PostMapping("/mypage/withdraw")
-    public String processWithdrawal(@AuthenticationPrincipal CustomUserDetails userDetails, RedirectAttributes rttr) {
-        rttr.addFlashAttribute("successMsg", "회원 탈퇴가 완료되었습니다. 이용해 주셔서 감사합니다.");
-        return "redirect:/";
+    @PostMapping("/mypage/verify-password")
+    @ResponseBody
+    public java.util.Map<String, Boolean> verifyPassword(@RequestParam String password, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        boolean isMatch = memberService.verifyPassword(userDetails.getMember().getId(), password);
+        return java.util.Map.of("success", isMatch);
     }
 
+    @PostMapping("/mypage/withdraw")
+    public String processWithdrawal(@RequestParam String password, @AuthenticationPrincipal CustomUserDetails userDetails, RedirectAttributes rttr, HttpServletRequest request) {
+        try {
+            Long memberId = userDetails.getMember().getId();
+
+            if (!memberService.verifyPassword(memberId, password)) {
+                rttr.addFlashAttribute("errorMsg", "비밀번호 검증에 실패하여 탈퇴가 취소되었습니다.");
+                return "redirect:/mypage/withdrawal";
+            }
+
+            memberService.deleteMember(memberId);
+
+            request.getSession().invalidate();
+            SecurityContextHolder.clearContext();
+
+            rttr.addFlashAttribute("successMsg", "회원 탈퇴가 완료되었습니다. 계정 정보는 1년간 안전하게 보관 후 파기됩니다.");
+            return "redirect:/";
+        } catch (Exception e) {
+            rttr.addFlashAttribute("errorMsg", "탈퇴 처리 도중 오류가 발생했습니다: " + e.getMessage());
+            return "redirect:/mypage/withdrawal";
+        }
+    }
+
+    // =========================================================================
+    // 🔥 [수정] 헬퍼 메서드: 계좌의 CLOSED 상태 판별 로직 추가
+    // =========================================================================
     private void populateAccountData(Member member, Model model) {
         dashboardService.populateHeader(member, model);
         List<AccountMember> memberships = accountMemberRepository.findByMemberId(member.getId());
@@ -266,25 +346,85 @@ public class MypageViewController {
         if (myMembership != null) {
             Account account = myMembership.getAccount();
             Long accountId = account.getId();
-            model.addAttribute("accountBalance", account.getBalance());
+            long totalBalance = account.getBalance();
+            boolean isClosed = "CLOSED".equals(account.getStatus().name());
+
+            model.addAttribute("accountBalance", totalBalance);
             model.addAttribute("accountNumber", account.getAccountNumber());
             model.addAttribute("hasActiveAccount", true);
+            model.addAttribute("isAccountClosed", isClosed);
+
             AccountMember partner = accountMemberRepository.findByAccountId(accountId).stream()
                     .filter(am -> !am.getMember().getId().equals(member.getId()))
                     .filter(am -> am.getInviteStatus() == InviteStatus.ACCEPT)
                     .findFirst().orElse(null);
-            model.addAttribute("partnerName", partner != null ? partner.getMember().getName() : "");
-            model.addAttribute("myDeposit", 0L);
-            model.addAttribute("partnerDeposit", 0L);
-            model.addAttribute("myRefund", account.getBalance() / 2);
-            model.addAttribute("partnerRefund", account.getBalance() / 2);
-            model.addAttribute("myContribution", 50.0);
-            model.addAttribute("partnerContribution", 50.0);
+
+            long myDepositAmt = myMembership.getTotalDeposit() != null ? myMembership.getTotalDeposit() : 0L;
+            long partnerDepositAmt = (partner != null && partner.getTotalDeposit() != null) ? partner.getTotalDeposit() : 0L;
+            long totalDepositAmt = myDepositAmt + partnerDepositAmt;
+
+            model.addAttribute("myDeposit", myDepositAmt);
+            model.addAttribute("partnerDeposit", partnerDepositAmt);
+
+            if (partner != null) {
+                model.addAttribute("partnerName", partner.getMember().getName());
+
+                String myAgree = myMembership.getAgreeClose();
+                String partnerAgree = partner.getAgreeClose();
+
+                if (isClosed) {
+                    model.addAttribute("accountClosureStatus", "closed");
+                    model.addAttribute("closureRequestedBy", "");
+                } else if ("Y".equals(myAgree) && "N".equals(partnerAgree)) {
+                    model.addAttribute("accountClosureStatus", "pending");
+                    model.addAttribute("closureRequestedBy", member.getName());
+                } else if ("N".equals(myAgree) && "Y".equals(partnerAgree)) {
+                    model.addAttribute("accountClosureStatus", "pending");
+                    model.addAttribute("closureRequestedBy", partner.getMember().getName());
+                } else {
+                    model.addAttribute("accountClosureStatus", "none");
+                    model.addAttribute("closureRequestedBy", "");
+                }
+
+                if (totalDepositAmt > 0) {
+                    double myRatio = (double) myDepositAmt / totalDepositAmt;
+                    double partnerRatio = (double) partnerDepositAmt / totalDepositAmt;
+                    long myRefundAmt = (long) Math.floor(totalBalance * myRatio);
+                    long partnerRefundAmt = totalBalance - myRefundAmt;
+
+                    model.addAttribute("myContribution", myRatio * 100.0);
+                    model.addAttribute("partnerContribution", partnerRatio * 100.0);
+                    model.addAttribute("myRefund", myRefundAmt);
+                    model.addAttribute("partnerRefund", partnerRefundAmt);
+                } else {
+                    model.addAttribute("myContribution", 50.0);
+                    model.addAttribute("partnerContribution", 50.0);
+                    model.addAttribute("myRefund", totalBalance / 2);
+                    model.addAttribute("partnerRefund", totalBalance - (totalBalance / 2));
+                }
+            } else {
+                model.addAttribute("partnerName", "연결 대기 중");
+
+                if (isClosed) {
+                    model.addAttribute("accountClosureStatus", "closed");
+                } else {
+                    model.addAttribute("accountClosureStatus", "none");
+                }
+
+                model.addAttribute("closureRequestedBy", "");
+                model.addAttribute("myContribution", 100.0);
+                model.addAttribute("partnerContribution", 0.0);
+                model.addAttribute("myRefund", totalBalance);
+                model.addAttribute("partnerRefund", 0L);
+            }
         } else {
             model.addAttribute("accountBalance", 0L);
             model.addAttribute("accountNumber", "");
             model.addAttribute("hasActiveAccount", false);
+            model.addAttribute("isAccountClosed", false);
             model.addAttribute("partnerName", "");
+            model.addAttribute("accountClosureStatus", "none");
+            model.addAttribute("closureRequestedBy", "");
             model.addAttribute("myDeposit", 0L);
             model.addAttribute("partnerDeposit", 0L);
             model.addAttribute("myRefund", 0L);
@@ -295,9 +435,8 @@ public class MypageViewController {
     }
 
     // =========================================================================
-    // 🔥 8. 카드 발급 워크플로우 (1단계 ~ 8단계 라우팅 및 세션 적재)
+    // 8. 카드 발급 워크플로우
     // =========================================================================
-
     @GetMapping("/mypage/card/step1")
     public String cardStep1(@AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
         Member freshMember = getFreshMember(userDetails.getMember().getId());
@@ -352,7 +491,6 @@ public class MypageViewController {
         return "domain/mypage/card-step7";
     }
 
-    // 🔥 최종 DB 저장 단계
     @PostMapping("/mypage/card/step7")
     public String processStep7(
             @RequestParam String recipientName, @RequestParam String address, @RequestParam String contactNumber,
@@ -375,7 +513,6 @@ public class MypageViewController {
                     .findFirst().orElseThrow(() -> new IllegalArgumentException("연결된 공동 계좌가 없습니다."))
                     .getAccount().getId();
 
-            // 💡 [재발급 핵심 로직] 새 카드를 발급받으면 기존 카드는 DB에서 삭제합니다!
             List<Card> existingCards = cardRepository.findByAccountId(accountId).stream()
                     .filter(c -> c.getMember().getId().equals(userDetails.getMember().getId()))
                     .collect(Collectors.toList());
@@ -383,14 +520,12 @@ public class MypageViewController {
                 cardRepository.deleteAll(existingCards);
             }
 
-            // 난수 카드 정보 생성
             String randomCardNum = String.format("%04d-%04d-%04d-%04d",
                     (int)(Math.random()*10000), (int)(Math.random()*10000),
                     (int)(Math.random()*10000), (int)(Math.random()*10000));
             java.time.LocalDate now = java.time.LocalDate.now();
             String expiryDate = String.format("%02d/%02d", now.getMonthValue(), (now.getYear() + 5) % 100);
 
-            // DTO 포장 및 저장
             CardCreateRequestDto requestDto = new CardCreateRequestDto();
             requestDto.setAccountId(accountId);
             requestDto.setMemberId(userDetails.getMember().getId());
@@ -411,9 +546,27 @@ public class MypageViewController {
     }
 
     @GetMapping("/mypage/card/step8")
-    public String cardStep8(@ModelAttribute("cardIssueSession") CardIssueSessionDto sessionDto, Model model, org.springframework.web.bind.support.SessionStatus status) {
-        model.addAttribute("cardDesign", sessionDto.getCardDesign());
-        model.addAttribute("cardAddress", sessionDto.getShippingAddress());
+    public String cardStep8(@AuthenticationPrincipal CustomUserDetails userDetails, Model model, org.springframework.web.bind.support.SessionStatus status) {
+        Member freshMember = getFreshMember(userDetails.getMember().getId());
+
+        Long accountId = accountMemberRepository.findByMemberId(freshMember.getId()).stream()
+                .filter(am -> am.getInviteStatus() == InviteStatus.ACCEPT && "GROUP".equals(am.getAccount().getAccountType().name()))
+                .findFirst().map(am -> am.getAccount().getId()).orElse(null);
+
+        if (accountId != null) {
+            Card myLatestCard = cardRepository.findByAccountId(accountId).stream()
+                    .filter(c -> c.getMember().getId().equals(freshMember.getId()))
+                    .max(Comparator.comparing(Card::getCreatedAt))
+                    .orElse(null);
+
+            if (myLatestCard != null) {
+                model.addAttribute("cardDesign", myLatestCard.getCardDesign() != null ? myLatestCard.getCardDesign() : "pink");
+            }
+        }
+
+        model.addAttribute("user", freshMember);
+        model.addAttribute("cardAddress", freshMember.getAddress() + (freshMember.getAddressDetail() != null ? " " + freshMember.getAddressDetail() : ""));
+
         status.setComplete();
         return "domain/mypage/card-step8";
     }

--- a/src/main/resources/templates/common/layout/mypage-sidebar.html
+++ b/src/main/resources/templates/common/layout/mypage-sidebar.html
@@ -2,7 +2,7 @@
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <body>
 <th:block th:fragment="sidebar(activeMenu)">
-    <aside class="w-72 bg-white border-r border-gray-200 p-6 flex-shrink-0 sticky top-24 h-[calc(100vh-6rem)] overflow-y-auto z-10">
+    <aside class="w-72 bg-white border-r border-gray-200 p-6 flex-shrink-0 sticky top-[96px] self-start h-[calc(100vh-96px)] overflow-y-auto z-20">
         <div class="space-y-2 mb-8">
 
             <a th:href="@{/mypage/profile}"

--- a/src/main/resources/templates/domain/mypage/accounts.html
+++ b/src/main/resources/templates/domain/mypage/accounts.html
@@ -19,6 +19,11 @@
     <div class="max-w-4xl">
       <h1 class="text-2xl text-gray-800 mb-8">연결 계좌</h1>
 
+      <div th:if="${successMsg}" class="mb-6 p-4 bg-green-50 border border-green-200 text-green-700 rounded-xl flex items-center gap-2">
+        <i data-lucide="check-circle" class="w-5 h-5"></i>
+        <span th:text="${successMsg}"></span>
+      </div>
+
       <div class="bg-gradient-to-r from-[#FCE8E3] to-[#FFE4E8] rounded-3xl shadow-md p-8 mb-6">
         <div class="flex items-center gap-3 mb-6">
           <div class="w-12 h-12 bg-white rounded-full flex items-center justify-center">
@@ -56,18 +61,14 @@
         <div class="space-y-4">
           <div class="flex items-center justify-between p-5 bg-[#FAFAFA] rounded-2xl">
             <span class="text-gray-600">계좌번호</span>
-            <span class="text-gray-800 font-mono" th:text="${accountNumber != null ? accountNumber : '계좌 없음'}">110-123456789-012</span>
+            <span class="text-gray-800 font-mono" th:text="${accountNumber != null and accountNumber != '' ? accountNumber : '계좌 없음'}">110-123456789-012</span>
           </div>
           <div class="flex items-center justify-between p-5 bg-[#FAFAFA] rounded-2xl">
             <span class="text-gray-600">계좌 상태</span>
             <div class="flex items-center gap-2">
-              <div class="w-2 h-2 bg-green-500 rounded-full"></div>
-              <span class="text-gray-800">정상</span>
+              <div th:class="${accountNumber != null and accountNumber != ''} ? 'w-2 h-2 bg-green-500 rounded-full' : 'w-2 h-2 bg-gray-400 rounded-full'"></div>
+              <span class="text-gray-800" th:text="${accountNumber != null and accountNumber != '' ? '정상' : '미개설'}">정상</span>
             </div>
-          </div>
-          <div class="flex items-center justify-between p-5 bg-[#FAFAFA] rounded-2xl">
-            <span class="text-gray-600">개설일</span>
-            <span class="text-gray-800">2026년 5월 13일</span>
           </div>
         </div>
       </div>
@@ -75,10 +76,10 @@
       <div class="bg-white rounded-3xl shadow-sm p-8">
         <h2 class="text-lg text-gray-800 mb-6">계좌 관리</h2>
         <div class="grid grid-cols-2 gap-4">
-          <button class="py-4 bg-[#FCE8E3] text-gray-800 rounded-2xl hover:bg-[#FBD5CE] transition-colors">이체한도 변경</button>
-          <button class="py-4 bg-[#FCE8E3] text-gray-800 rounded-2xl hover:bg-[#FBD5CE] transition-colors">계좌 비밀번호 변경</button>
-          <button class="py-4 bg-[#FCE8E3] text-gray-800 rounded-2xl hover:bg-[#FBD5CE] transition-colors">거래 내역 다운로드</button>
-          <button class="py-4 bg-[#FCE8E3] text-gray-800 rounded-2xl hover:bg-[#FBD5CE] transition-colors">계좌 증명서 발급</button>
+          <button onclick="alert('이체한도 변경 기능은 준비 중입니다.')" class="py-4 bg-[#FCE8E3] text-gray-800 rounded-2xl hover:bg-[#FBD5CE] transition-colors">이체한도 변경</button>
+          <button onclick="alert('계좌 비밀번호 변경 기능은 준비 중입니다.')" class="py-4 bg-[#FCE8E3] text-gray-800 rounded-2xl hover:bg-[#FBD5CE] transition-colors">계좌 비밀번호 변경</button>
+          <button onclick="alert('거래 내역 다운로드 서비스는 준비 중입니다.')" class="py-4 bg-[#FCE8E3] text-gray-800 rounded-2xl hover:bg-[#FBD5CE] transition-colors">거래 내역 다운로드</button>
+          <button onclick="alert('계좌 증명서 발급 서비스는 준비 중입니다.')" class="py-4 bg-[#FCE8E3] text-gray-800 rounded-2xl hover:bg-[#FBD5CE] transition-colors">계좌 증명서 발급</button>
         </div>
       </div>
 

--- a/src/main/resources/templates/domain/mypage/card-step7.html
+++ b/src/main/resources/templates/domain/mypage/card-step7.html
@@ -41,7 +41,7 @@
         </div>
         <div>
           <label class="block text-gray-800 mb-2 text-lg">연락처</label>
-          <input type="tel" id="contactNumber" th:value="${user.phoneNo}" placeholder="연락처를 입력하세요" oninput="this.value=this.value.replace(/[^0-9]/g,''); checkCanProceed()" class="w-full px-5 py-4 border-2 border-gray-200 rounded-2xl focus:border-[#F5A5A5] focus:outline-none transition-colors text-gray-800"/>
+          <input type="tel" id="contactNumber" th:value="${user.phoneNo}" placeholder="연락처를 입력하세요" maxlength="13" oninput="formatPhone(this); checkCanProceed()" class="w-full px-5 py-4 border-2 border-gray-200 rounded-2xl focus:border-[#F5A5A5] focus:outline-none transition-colors text-gray-800"/>
         </div>
         <div class="bg-[#FCE8E3] rounded-2xl p-5">
           <label class="flex items-center gap-3 cursor-pointer">
@@ -70,14 +70,31 @@
   const serverUserAddress = /*[[${user != null ? user.address : null}]]*/ null;
   const serverUserPhone   = /*[[${user != null ? user.phoneNo : null}]]*/ null;
 
+  // 🔥 [추가됨] 전화번호 하이픈 템플릿 함수 선언
+  function formatPhone(input) {
+    const digits = input.value.replace(/[^0-9]/g, '').slice(0, 11);
+    if (digits.length < 4)       input.value = digits;
+    else if (digits.length < 8)  input.value = digits.slice(0, 3) + '-' + digits.slice(3);
+    else                         input.value = digits.slice(0, 3) + '-' + digits.slice(3, 7) + '-' + digits.slice(7);
+  }
+
   function handleSameAsProfile(checkbox) {
     const name    = serverUserName    || '';
     const address = serverUserAddress || '';
     const phone   = serverUserPhone   || '';
     const disabled = checkbox.checked;
+
     document.getElementById('recipientName').value = disabled ? name : '';
     document.getElementById('address').value       = disabled ? address : '';
-    document.getElementById('contactNumber').value = disabled ? phone : '';
+
+    const phoneInput = document.getElementById('contactNumber');
+    phoneInput.value = disabled ? phone : '';
+
+    // 🔥 [추가됨] 체크박스로 프로필 정보를 가져올 때 즉각적인 하이픈 적용
+    if (disabled && phoneInput.value) {
+      formatPhone(phoneInput);
+    }
+
     document.getElementById('recipientName').disabled = disabled;
     document.getElementById('address').disabled       = disabled;
     document.getElementById('contactNumber').disabled = disabled;
@@ -99,12 +116,13 @@
   function goNext() {
     const name    = document.getElementById('recipientName').value.trim();
     const address = document.getElementById('address').value.trim();
+    // 백엔드로 전송 시 하이픈 포함된 형태 그대로 전송(UI 표시 통일)
     const contact = document.getElementById('contactNumber').value.trim();
 
     if (name && address && contact) {
       const form = document.createElement('form');
       form.method = 'POST';
-      form.action = '/mypage/card/step7'; // 🔥 컨트롤러의 최종 발급 요청으로 전송
+      form.action = '/mypage/card/step7';
 
       const csrf = document.createElement('input');
       csrf.type = 'hidden'; csrf.name = '_csrf'; csrf.value = /*[[${_csrf.token}]]*/ '';
@@ -120,6 +138,12 @@
   }
 
   window.addEventListener('DOMContentLoaded', function() {
+    // 🔥 [추가됨] 페이지 첫 렌더링 시에도 서버로부터 주입된 초기값 하이픈 렌더링 적용
+    const phoneInput = document.getElementById('contactNumber');
+    if (phoneInput && phoneInput.value) {
+      formatPhone(phoneInput);
+    }
+
     checkCanProceed();
     lucide.createIcons();
   });

--- a/src/main/resources/templates/domain/mypage/cards.html
+++ b/src/main/resources/templates/domain/mypage/cards.html
@@ -128,7 +128,7 @@
                     <div class="flex items-center gap-2 mb-1">
                       <p class="text-sm text-gray-600">CVV</p>
                       <button onclick="toggleCVV()" class="text-sm text-[#F5A5A5] hover:underline">
-                        <i data-lucide="eye" id="eyeCvv" class="w-4 h-4"></i>
+                        <i data-lucide="eye-off" id="eyeCvv" class="w-4 h-4"></i>
                       </button>
                     </div>
                     <p id="cvvDisplay" class="text-lg text-gray-800 font-mono">***</p>
@@ -222,7 +222,7 @@
           <div class="bg-gray-100 flex-1 h-12 flex items-center px-4 rounded shadow-inner overflow-hidden">
             <span class="text-gray-400 italic text-lg signature-font" style="font-family: cursive;" th:text="${userName}">김민수</span>
           </div>
-          <div class="bg-white px-4 flex items-center justify-center font-mono text-gray-800 text-lg font-bold rounded shadow-inner w-20">
+          <div class="bg-white px-4 flex items-center justify-center font-mono text-gray-800 text-lg font-bold rounded shadow-inner w-20" th:text="${cardCvv != null ? cardCvv : '123'}">
             123
           </div>
         </div>
@@ -247,6 +247,8 @@
 <script th:inline="javascript">
   const serverCardDesign = /*[[${cardDesign}]]*/ 'pink';
   const serverCardType   = /*[[${cardType}]]*/ 'domestic';
+  // 🔥 백엔드에서 주입한 동적 CVV 변수 받기
+  const serverCvv        = /*[[${cardCvv != null ? cardCvv : '123'}]]*/ '123';
   let cardStatus         = /*[[${cardStatus}]]*/ 'ACTIVE';
 
   const cardColors = {
@@ -346,11 +348,12 @@
     lucide.createIcons();
   }
 
+  // 🔥 [수정] 하드코딩 123 제거 후 동적 CVV 토글 적용
   function toggleCVV() {
     const el = document.getElementById('cvvDisplay');
     const icon = document.getElementById('eyeCvv');
-    const showing = el.textContent === '123';
-    el.textContent = showing ? '***' : '123';
+    const showing = el.textContent === serverCvv;
+    el.textContent = showing ? '***' : serverCvv;
     icon.setAttribute('data-lucide', showing ? 'eye' : 'eye-off');
     lucide.createIcons();
   }

--- a/src/main/resources/templates/domain/mypage/close-account.html
+++ b/src/main/resources/templates/domain/mypage/close-account.html
@@ -19,6 +19,11 @@
         <div class="max-w-4xl">
             <h1 class="text-2xl font-bold text-gray-800 mb-8">계좌 해지</h1>
 
+            <div th:if="${successMsg}" class="mb-6 p-4 bg-green-50 border border-green-200 text-green-700 rounded-xl flex items-center gap-2">
+                <i data-lucide="check-circle" class="w-5 h-5"></i>
+                <span th:text="${successMsg}"></span>
+            </div>
+
             <div class="space-y-6">
                 <h2 class="text-lg font-bold text-gray-800">커플 통장</h2>
 
@@ -32,12 +37,12 @@
                     </div>
                 </div>
 
-                <div id="closureStatusBanner" class="hidden rounded-xl p-6 border-2 bg-blue-50 border-blue-200">
+                <div id="closureStatusBanner" class="hidden rounded-xl p-6 border-2">
                     <div class="flex items-start gap-3">
-                        <span id="closureStatusIcon" class="text-2xl">⏳</span>
+                        <span id="closureStatusIcon" class="text-2xl"></span>
                         <div>
-                            <h3 id="closureStatusTitle" class="font-bold mb-2 text-blue-800">계좌 해지 요청 대기 중</h3>
-                            <p id="closureStatusDesc" class="text-sm leading-relaxed text-blue-700">파트너가 동의하면 계좌가 해지됩니다.</p>
+                            <h3 id="closureStatusTitle" class="font-bold mb-2"></h3>
+                            <p id="closureStatusDesc" class="text-sm leading-relaxed"></p>
                         </div>
                     </div>
                 </div>
@@ -48,13 +53,14 @@
                             <div class="flex items-center gap-2 mb-3">
                                 <h3 class="text-lg font-bold text-gray-800">우리의 커플 통장</h3>
                                 <span class="px-3 py-1 bg-pink-100 text-pink-700 text-xs rounded-lg">💕 커플</span>
-                                <span class="px-3 py-1 bg-green-100 text-green-700 text-xs rounded-lg">활성</span>
+                                <span th:if="${accountClosureStatus != 'closed'}" class="px-3 py-1 bg-green-100 text-green-700 text-xs rounded-lg">활성</span>
+                                <span th:if="${accountClosureStatus == 'closed'}" class="px-3 py-1 bg-gray-100 text-gray-700 text-xs rounded-lg">해지됨</span>
                             </div>
                             <div class="space-y-1 text-sm text-gray-600">
                                 <div>계좌번호: <span class="font-mono">1002-9876-5432</span></div>
-                                <div>잔액: <span class="text-xl font-bold text-gray-900">₩<span th:text="${accountBalance != null ? #numbers.formatInteger(accountBalance, 0, 'COMMA') : '1,245,000'}" id="closeAccountBalance">1,245,000</span></span></div>
+                                <div>잔액: <span class="text-xl font-bold text-gray-900">₩<span th:text="${accountBalance != null ? #numbers.formatInteger(accountBalance, 0, 'COMMA') : '0'}" id="closeAccountBalance">0</span></span></div>
                                 <div>개설일: 2026.01.15</div>
-                                <div>파트너: <span th:text="${partnerName != null ? partnerName : '이서연'}" id="closePartnerName">이서연</span></div>
+                                <div>파트너: <span th:text="${partnerName != null ? partnerName : '대기 중'}" id="closePartnerName">대기 중</span></div>
                             </div>
                         </div>
                     </div>
@@ -63,15 +69,15 @@
                     <div class="grid grid-cols-3 gap-4 mb-6">
                         <div class="text-center">
                             <div class="text-xs text-gray-500 mb-1">이번 달 지출</div>
-                            <div class="text-lg font-bold text-gray-900">₩854,000</div>
+                            <div class="text-lg font-bold text-gray-900">₩<span th:text="${thisMonthSpend != null ? #numbers.formatInteger(thisMonthSpend, 0, 'COMMA') : '0'}">0</span></div>
                         </div>
                         <div class="text-center">
                             <div class="text-xs text-gray-500 mb-1">목표 저축</div>
-                            <div class="text-lg font-bold text-gray-900">₩3,500,000</div>
+                            <div class="text-lg font-bold text-gray-900">₩<span th:text="${targetSavings != null ? #numbers.formatInteger(targetSavings, 0, 'COMMA') : '0'}">0</span></div>
                         </div>
                         <div class="text-center">
                             <div class="text-xs text-gray-500 mb-1">적립 포인트</div>
-                            <div class="text-lg font-bold text-pink-500" th:text="${userPoints != null ? userPoints + 'P' : '12,450P'}">12,450P</div>
+                            <div class="text-lg font-bold text-pink-500" th:text="${couplePoints != null ? #numbers.formatInteger(couplePoints, 0, 'COMMA') + 'P' : '0P'}">0P</div>
                         </div>
                     </div>
 
@@ -82,14 +88,14 @@
                         </div>
                         <div class="grid grid-cols-2 gap-4">
                             <div class="bg-white rounded-lg p-3 border border-blue-200">
-                                <div class="text-xs text-gray-600 mb-1" id="closeMyName" th:text="${userName != null ? userName + '님' : '김민수님'}">김민수님</div>
-                                <div class="text-xl font-bold text-blue-600">₩<span th:text="${myRefund != null ? #numbers.formatInteger(myRefund, 0, 'COMMA') : '740,736'}" id="closeMyRefund">740,736</span></div>
-                                <div class="text-xs text-gray-500 mt-1">기여도 <span th:text="${myContribution != null ? #numbers.formatDecimal(myContribution, 1, 1) + '%' : '56.5%'}" id="closeMyContrib">56.5%</span></div>
+                                <div class="text-xs text-gray-600 mb-1" id="closeMyName" th:text="${userName != null ? userName + '님' : '나'}">나</div>
+                                <div class="text-xl font-bold text-blue-600">₩<span th:text="${myRefund != null ? #numbers.formatInteger(myRefund, 0, 'COMMA') : '0'}" id="closeMyRefund">0</span></div>
+                                <div class="text-xs text-gray-500 mt-1">기여도 <span th:text="${myContribution != null ? #numbers.formatDecimal(myContribution, 1, 1) + '%' : '0.0%'}" id="closeMyContrib">0.0%</span></div>
                             </div>
                             <div class="bg-white rounded-lg p-3 border border-pink-200">
-                                <div class="text-xs text-gray-600 mb-1" id="closePartnerNameRefund" th:text="${partnerName != null ? partnerName + '님' : '이서연님'}">이서연님</div>
-                                <div class="text-xl font-bold text-pink-600">₩<span th:text="${partnerRefund != null ? #numbers.formatInteger(partnerRefund, 0, 'COMMA') : '504,264'}" id="closePartnerRefund">504,264</span></div>
-                                <div class="text-xs text-gray-500 mt-1">기여도 <span th:text="${partnerContribution != null ? #numbers.formatDecimal(partnerContribution, 1, 1) + '%' : '43.5%'}" id="closePartnerContrib">43.5%</span></div>
+                                <div class="text-xs text-gray-600 mb-1" id="closePartnerNameRefund" th:text="${partnerName != null ? partnerName + '님' : '파트너님'}">파트너님</div>
+                                <div class="text-xl font-bold text-pink-600">₩<span th:text="${partnerRefund != null ? #numbers.formatInteger(partnerRefund, 0, 'COMMA') : '0'}" id="closePartnerRefund">0</span></div>
+                                <div class="text-xs text-gray-500 mt-1">기여도 <span th:text="${partnerContribution != null ? #numbers.formatDecimal(partnerContribution, 1, 1) + '%' : '0.0%'}" id="closePartnerContrib">0.0%</span></div>
                             </div>
                         </div>
                         <button onclick="showRefundModal()" class="w-full mt-3 text-sm text-blue-600 hover:text-blue-700 font-medium">상세 내역 확인하기</button>
@@ -131,34 +137,34 @@
 
             <div class="bg-[#FCE8E3] rounded-xl p-6 mb-6">
                 <div class="text-sm text-gray-600 mb-2">현재 계좌 잔액</div>
-                <div class="text-4xl font-bold text-gray-900">₩<span id="refundBalance">1,245,000</span></div>
+                <div class="text-4xl font-bold text-gray-900">₩<span id="refundBalance">0</span></div>
             </div>
 
             <div class="grid grid-cols-2 gap-4 mb-6">
-                <div class="bg-blue-50 rounded-xl p-5 border-2 border-blue-200">
-                    <h3 id="refundMyTitle" class="text-sm font-bold text-gray-800 mb-4">김민수님의 송금 내역</h3>
-                    <div class="space-y-2 mb-4">
-                        <div class="flex justify-between text-sm"><span class="text-gray-600">2026.05.01</span><span class="text-blue-600 font-semibold">+₩500,000</span></div>
-                        <div class="flex justify-between text-sm"><span class="text-gray-600">2026.04.01</span><span class="text-blue-600 font-semibold">+₩500,000</span></div>
-                        <div class="flex justify-between text-sm"><span class="text-gray-600">2026.03.01</span><span class="text-blue-600 font-semibold">+₩300,000</span></div>
-                        <div class="flex justify-between text-sm"><span class="text-gray-600">2026.02.01</span><span class="text-blue-600 font-semibold">+₩200,000</span></div>
+                <div class="bg-blue-50 rounded-xl p-5 border-2 border-blue-200 flex flex-col justify-between">
+                    <div>
+                        <h3 id="refundMyTitle" class="text-sm font-bold text-gray-800 mb-4">내 송금 내역</h3>
+                        <div class="bg-white/60 rounded-lg p-4 text-center mb-4">
+                            <i data-lucide="receipt" class="w-6 h-6 text-blue-400 mx-auto mb-2"></i>
+                            <span class="text-xs text-gray-500 leading-tight">상세 송금 내역은<br>소비기록 메뉴에서 확인 가능합니다.</span>
+                        </div>
                     </div>
                     <div class="border-t-2 border-blue-300 pt-3 space-y-2">
-                        <div class="flex justify-between"><span class="text-sm text-gray-600">총 송금액</span><span class="text-lg font-bold text-blue-600">₩1,500,000</span></div>
-                        <div class="flex justify-between"><span class="text-sm text-gray-600">기여도</span><span id="refundMyContrib2" class="text-lg font-bold text-blue-600">56.5%</span></div>
+                        <div class="flex justify-between"><span class="text-sm text-gray-600">총 송금액</span><span id="refundMyTotalDeposit" class="text-lg font-bold text-blue-600">₩0</span></div>
+                        <div class="flex justify-between"><span class="text-sm text-gray-600">기여도</span><span id="refundMyContrib2" class="text-lg font-bold text-blue-600">0.0%</span></div>
                     </div>
                 </div>
-                <div class="bg-pink-50 rounded-xl p-5 border-2 border-pink-200">
-                    <h3 id="refundPartnerTitle" class="text-sm font-bold text-gray-800 mb-4">이서연님의 송금 내역</h3>
-                    <div class="space-y-2 mb-4">
-                        <div class="flex justify-between text-sm"><span class="text-gray-600">2026.04.15</span><span class="text-pink-600 font-semibold">+₩400,000</span></div>
-                        <div class="flex justify-between text-sm"><span class="text-gray-600">2026.03.15</span><span class="text-pink-600 font-semibold">+₩350,000</span></div>
-                        <div class="flex justify-between text-sm"><span class="text-gray-600">2026.02.15</span><span class="text-pink-600 font-semibold">+₩250,000</span></div>
-                        <div class="flex justify-between text-sm"><span class="text-gray-600">2026.01.20</span><span class="text-pink-600 font-semibold">+₩150,000</span></div>
+                <div class="bg-pink-50 rounded-xl p-5 border-2 border-pink-200 flex flex-col justify-between">
+                    <div>
+                        <h3 id="refundPartnerTitle" class="text-sm font-bold text-gray-800 mb-4">파트너 송금 내역</h3>
+                        <div class="bg-white/60 rounded-lg p-4 text-center mb-4">
+                            <i data-lucide="receipt" class="w-6 h-6 text-pink-400 mx-auto mb-2"></i>
+                            <span class="text-xs text-gray-500 leading-tight">상세 송금 내역은<br>소비기록 메뉴에서 확인 가능합니다.</span>
+                        </div>
                     </div>
                     <div class="border-t-2 border-pink-300 pt-3 space-y-2">
-                        <div class="flex justify-between"><span class="text-sm text-gray-600">총 송금액</span><span class="text-lg font-bold text-pink-600">₩1,150,000</span></div>
-                        <div class="flex justify-between"><span class="text-sm text-gray-600">기여도</span><span id="refundPartnerContrib2" class="text-lg font-bold text-pink-600">43.5%</span></div>
+                        <div class="flex justify-between"><span class="text-sm text-gray-600">총 송금액</span><span id="refundPartnerTotalDeposit" class="text-lg font-bold text-pink-600">₩0</span></div>
+                        <div class="flex justify-between"><span class="text-sm text-gray-600">기여도</span><span id="refundPartnerContrib2" class="text-lg font-bold text-pink-600">0.0%</span></div>
                     </div>
                 </div>
             </div>
@@ -166,14 +172,14 @@
             <h3 class="text-lg font-bold text-gray-800 mb-4">환급 예상 금액</h3>
             <div class="grid grid-cols-2 gap-4 mb-6">
                 <div class="bg-white rounded-xl p-5 border-2 border-blue-200">
-                    <div id="refundMyName2" class="text-sm text-gray-600 mb-1">김민수님</div>
-                    <div id="refundMyAmt" class="text-3xl font-bold text-blue-600 mb-1">₩740,736</div>
-                    <div id="refundMyContrib3" class="text-xs text-gray-500">기여도 56.5% 기준</div>
+                    <div id="refundMyName2" class="text-sm text-gray-600 mb-1">나</div>
+                    <div id="refundMyAmt" class="text-3xl font-bold text-blue-600 mb-1">₩0</div>
+                    <div id="refundMyContrib3" class="text-xs text-gray-500">기여도 0.0% 기준</div>
                 </div>
                 <div class="bg-white rounded-xl p-5 border-2 border-pink-200">
-                    <div id="refundPartnerName2" class="text-sm text-gray-600 mb-1">이서연님</div>
-                    <div id="refundPartnerAmt" class="text-3xl font-bold text-pink-600 mb-1">₩504,264</div>
-                    <div id="refundPartnerContrib3" class="text-xs text-gray-500">기여도 43.5% 기준</div>
+                    <div id="refundPartnerName2" class="text-sm text-gray-600 mb-1">파트너</div>
+                    <div id="refundPartnerAmt" class="text-3xl font-bold text-pink-600 mb-1">₩0</div>
+                    <div id="refundPartnerContrib3" class="text-xs text-gray-500">기여도 0.0% 기준</div>
                 </div>
             </div>
 
@@ -182,7 +188,7 @@
                     <span class="text-lg">ℹ️</span>
                     <div>
                         <h4 class="text-sm font-semibold text-gray-800 mb-2">환급 방식 안내</h4>
-                        <p class="text-sm text-gray-700">환급액은 각자가 송금한 금액의 비율(기여도)에 따라 계산됩니다. 위 금액이 각자의 등록된 계좌로 자동 송금됩니다.</p>
+                        <p class="text-sm text-gray-700">환급액은 사용 후 남은 잔액을 기준으로, 각자가 송금한 총액의 비율(기여도)에 따라 정확히 계산됩니다.</p>
                     </div>
                 </div>
             </div>
@@ -207,9 +213,11 @@
     const serverMyContrib    = /*[[${myContribution}]]*/ null;
     const serverPartnerContrib= /*[[${partnerContribution}]]*/ null;
     const serverBalance      = /*[[${accountBalance}]]*/ null;
+    const serverMyDeposit    = /*[[${myDeposit}]]*/ 0;
+    const serverPartnerDeposit= /*[[${partnerDeposit}]]*/ 0;
 
-    let userName          = serverUserName || '김민수';
-    let partnerName       = serverPartnerName || '이서연';
+    let userName          = serverUserName || '나';
+    let partnerName       = serverPartnerName || '파트너';
     let closureStatus     = serverClosureStatus || 'none';
     let closureRequestedBy= serverClosureBy || '';
 
@@ -219,39 +227,75 @@
       lucide.createIcons();
     });
 
+    // 🔥 [수정] 해지 완료(closed) 상태일 때 버튼 및 배너를 회색으로 비활성화하는 로직 추가
     function initClosureSection() {
       const banner = document.getElementById('closureStatusBanner');
       const btn    = document.getElementById('closureActionBtn');
-      if (closureStatus === 'pending') {
+
+      if (closureStatus === 'closed') {
+        banner.classList.remove('hidden');
+        banner.className = 'rounded-xl p-6 border-2 bg-gray-50 border-gray-200';
+        document.getElementById('closureStatusIcon').textContent  = '✅';
+        document.getElementById('closureStatusTitle').className = 'font-bold mb-2 text-gray-800';
+        document.getElementById('closureStatusTitle').textContent = '계좌 해지 완료';
+        document.getElementById('closureStatusDesc').className = 'text-sm leading-relaxed text-gray-600';
+        document.getElementById('closureStatusDesc').textContent  = '이 계좌는 이미 성공적으로 해지 및 정산이 완료되었습니다.';
+
+        btn.className = 'w-full py-4 rounded-xl transition-colors font-medium text-lg bg-gray-300 text-white cursor-not-allowed';
+        btn.textContent = '이미 해지된 계좌입니다';
+        btn.disabled = true;
+
+      } else if (closureStatus === 'pending') {
         banner.classList.remove('hidden');
         if (closureRequestedBy === userName) {
           banner.className = 'rounded-xl p-6 border-2 bg-blue-50 border-blue-200';
           document.getElementById('closureStatusIcon').textContent  = '⏳';
+          document.getElementById('closureStatusTitle').className = 'font-bold mb-2 text-blue-800';
           document.getElementById('closureStatusTitle').textContent = '계좌 해지 요청 대기 중';
-          document.getElementById('closureStatusDesc').textContent  = `${partnerName}님이 동의하면 계좌가 해지됩니다.`;
+          document.getElementById('closureStatusDesc').className = 'text-sm leading-relaxed text-blue-700';
+          document.getElementById('closureStatusDesc').textContent  = `${partnerName}님이 동의하면 최종 정산 및 해지됩니다.`;
+
           btn.className = 'w-full py-4 rounded-xl transition-colors font-medium text-lg bg-gray-500 hover:bg-gray-600 text-white';
-          btn.textContent = '커플 통장 해지 취소하기';
+          btn.textContent = '해지 요청 취소하기';
+          btn.disabled = false;
         } else {
           banner.className = 'rounded-xl p-6 border-2 bg-orange-50 border-orange-200';
           document.getElementById('closureStatusIcon').textContent  = '⚠️';
+          document.getElementById('closureStatusTitle').className = 'font-bold mb-2 text-orange-800';
           document.getElementById('closureStatusTitle').textContent = `${closureRequestedBy}님이 계좌 해지를 요청했습니다`;
-          document.getElementById('closureStatusDesc').textContent  = '환급액을 확인하고 해지에 동의하거나 거절할 수 있습니다.';
+          document.getElementById('closureStatusDesc').className = 'text-sm leading-relaxed text-orange-700';
+          document.getElementById('closureStatusDesc').textContent  = '환급액을 확인하고 해지에 동의해주세요.';
+
           btn.className = 'w-full py-4 rounded-xl transition-colors font-medium text-lg bg-orange-500 hover:bg-orange-600 text-white';
-          btn.textContent = '커플 통장 해지 동의하기';
+          btn.textContent = '해지 동의하기';
+          btn.disabled = false;
         }
       } else {
         banner.classList.add('hidden');
         btn.className = 'w-full py-4 rounded-xl transition-colors font-medium text-lg bg-red-500 hover:bg-red-600 text-white';
         btn.textContent = '커플 통장 해지 요청하기';
+        btn.disabled = false;
       }
     }
 
     function handleClosureAction() {
+      // 해지 완료 상태면 클릭 무시
+      if (closureStatus === 'closed') return;
+
       if (closureStatus === 'pending' && closureRequestedBy === userName) {
-        if (confirm('계좌 해지 요청을 취소하시겠습니까?')) {
-          closureStatus = 'none'; closureRequestedBy = '';
-          alert('계좌 해지 요청이 취소되었습니다.');
-          initClosureSection();
+        if (confirm('계좌 해지 요청을 취소하시겠습니까? 파트너의 화면에서도 대기 상태가 해제됩니다.')) {
+            const form = document.createElement('form');
+            form.method = 'POST';
+            form.action = '/mypage/close-account/cancel';
+
+            const csrf = document.createElement('input');
+            csrf.type = 'hidden';
+            csrf.name = '_csrf';
+            csrf.value = /*[[${_csrf.token}]]*/ '';
+            form.appendChild(csrf);
+
+            document.body.appendChild(form);
+            form.submit();
         }
       } else {
         showRefundModal();
@@ -262,12 +306,9 @@
       document.getElementById('refundModalOverlay').classList.remove('hidden');
       document.getElementById('refundModal').classList.remove('hidden');
       const btn = document.getElementById('refundConfirmBtn');
-      if (closureStatus === 'pending' && closureRequestedBy === userName) {
-        btn.className = 'flex-1 py-4 rounded-xl transition-colors font-medium bg-gray-500 text-white hover:bg-gray-600';
-        btn.textContent = '해지 요청 취소하기';
-      } else if (closureStatus === 'pending') {
+      if (closureStatus === 'pending' && closureRequestedBy !== userName) {
         btn.className = 'flex-1 py-4 rounded-xl transition-colors font-medium bg-orange-500 text-white hover:bg-orange-600';
-        btn.textContent = '해지 동의하기';
+        btn.textContent = '해지 동의 및 정산받기';
       } else {
         btn.className = 'flex-1 py-4 rounded-xl transition-colors font-medium bg-red-500 text-white hover:bg-red-600';
         btn.textContent = '해지 요청하기';
@@ -280,39 +321,48 @@
     }
 
     function handleConfirmClosure() {
-      if (closureStatus === 'pending' && closureRequestedBy === userName) {
-        if (confirm('계좌 해지 요청을 취소하시겠습니까?')) {
-          closureStatus = 'none'; closureRequestedBy = '';
-          alert('계좌 해지 요청이 취소되었습니다.');
-          hideRefundModal(); initClosureSection();
-        }
-      } else if (closureStatus === 'pending') {
-        if (confirm(`${closureRequestedBy}님의 계좌 해지 요청에 동의하시겠습니까?\n\n동의하시면 계좌가 즉시 해지됩니다.`)) {
-          alert('계좌 해지가 완료되었습니다.\n환급 금액은 1-2 영업일 내 입금됩니다.');
-          closureStatus = 'none'; hideRefundModal(); initClosureSection();
-        }
-      } else {
-        closureStatus = 'pending'; closureRequestedBy = userName;
-        alert(`계좌 해지 요청이 완료되었습니다.\n\n${partnerName}님이 동의하면 계좌가 해지됩니다.`);
-        hideRefundModal(); initClosureSection();
+      if (confirm('정말 계좌를 해지하시겠습니까?\n모든 잔액은 각자의 기여도에 맞춰 주계좌로 분배되며 되돌릴 수 없습니다.')) {
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = '/mypage/close-account';
+
+        const csrf = document.createElement('input');
+        csrf.type = 'hidden';
+        csrf.name = '_csrf';
+        csrf.value = /*[[${_csrf.token}]]*/ '';
+        form.appendChild(csrf);
+
+        document.body.appendChild(form);
+        form.submit();
       }
     }
 
     function initRefundModal() {
-      const myR = serverMyRefund !== null ? serverMyRefund : 740736;
-      const prR = serverPartnerRefund !== null ? serverPartnerRefund : 504264;
-      const myC = serverMyContrib !== null ? serverMyContrib : 56.5;
-      const prC = serverPartnerContrib !== null ? serverPartnerContrib : 43.5;
-      const bal = serverBalance !== null ? serverBalance : 1245000;
+      const myR = serverMyRefund !== null ? serverMyRefund : 0;
+      const prR = serverPartnerRefund !== null ? serverPartnerRefund : 0;
+      const myC = serverMyContrib !== null ? serverMyContrib : 100.0;
+      const prC = serverPartnerContrib !== null ? serverPartnerContrib : 0.0;
+      const bal = serverBalance !== null ? serverBalance : 0;
+      const myDep = serverMyDeposit !== null ? serverMyDeposit : 0;
+      const prDep = serverPartnerDeposit !== null ? serverPartnerDeposit : 0;
+
       document.getElementById('refundBalance').textContent     = bal.toLocaleString();
+
       document.getElementById('refundMyTitle').textContent     = userName + '님의 송금 내역';
       document.getElementById('refundPartnerTitle').textContent= partnerName + '님의 송금 내역';
+
+      document.getElementById('refundMyTotalDeposit').textContent = '₩' + myDep.toLocaleString();
+      document.getElementById('refundPartnerTotalDeposit').textContent = '₩' + prDep.toLocaleString();
+
       document.getElementById('refundMyContrib2').textContent  = myC.toFixed(1) + '%';
       document.getElementById('refundPartnerContrib2').textContent = prC.toFixed(1) + '%';
+
       document.getElementById('refundMyName2').textContent     = userName + '님';
       document.getElementById('refundPartnerName2').textContent= partnerName + '님';
+
       document.getElementById('refundMyAmt').textContent       = '₩' + myR.toLocaleString();
       document.getElementById('refundPartnerAmt').textContent  = '₩' + prR.toLocaleString();
+
       document.getElementById('refundMyContrib3').textContent  = '기여도 ' + myC.toFixed(1) + '% 기준';
       document.getElementById('refundPartnerContrib3').textContent = '기여도 ' + prC.toFixed(1) + '% 기준';
     }

--- a/src/main/resources/templates/domain/mypage/items.html
+++ b/src/main/resources/templates/domain/mypage/items.html
@@ -19,6 +19,15 @@
         <div id="section-items" class="max-w-4xl">
             <h1 class="text-2xl font-bold text-gray-800 mb-8">아이템 관리</h1>
 
+            <div th:if="${successMsg}" class="mb-6 p-4 bg-green-50 border border-green-200 text-green-700 rounded-xl flex items-center gap-2">
+                <i data-lucide="check-circle" class="w-5 h-5"></i>
+                <span th:text="${successMsg}"></span>
+            </div>
+            <div th:if="${errorMsg}" class="mb-6 p-4 bg-red-50 border border-red-200 text-red-700 rounded-xl flex items-center gap-2">
+                <i data-lucide="alert-circle" class="w-5 h-5"></i>
+                <span th:text="${errorMsg}"></span>
+            </div>
+
             <div class="bg-white rounded-3xl shadow-sm p-8 mb-6">
                 <div class="flex items-center justify-between mb-6">
                     <h2 class="text-lg font-bold text-gray-800">보유 테마</h2>
@@ -27,7 +36,8 @@
                 </div>
                 <div class="grid grid-cols-3 gap-4">
                     <th:block th:each="theme : ${purchasedThemes}">
-                        <div th:class="${theme.isActive} ? 'relative bg-gradient-to-br from-[#FFB6D9] to-[#FFE4F0] rounded-2xl p-6 aspect-square flex flex-col items-center justify-center border-4 border-[#F5A5A5]' : 'relative bg-gradient-to-br from-[#FFB6D9] to-[#FFE4F0] rounded-2xl p-6 aspect-square flex flex-col items-center justify-center hover:scale-105 transition-transform cursor-pointer'">
+                        <div th:onclick="|equipItem(${theme.id})|"
+                             th:class="${theme.isActive} ? 'relative bg-gradient-to-br from-[#FFB6D9] to-[#FFE4F0] rounded-2xl p-6 aspect-square flex flex-col items-center justify-center border-4 border-[#F5A5A5] cursor-pointer' : 'relative bg-gradient-to-br from-[#FFB6D9] to-[#FFE4F0] rounded-2xl p-6 aspect-square flex flex-col items-center justify-center hover:scale-105 transition-transform cursor-pointer'">
                             <div th:if="${theme.isActive}" class="absolute top-2 right-2 px-3 py-1 bg-[#F5A5A5] text-white text-xs rounded-full">사용 중</div>
                             <div class="text-6xl mb-3" th:text="${theme.image}">🌸</div>
                             <p class="text-sm text-gray-800 text-center font-medium" th:text="${theme.name}">테마 이름</p>
@@ -46,11 +56,6 @@
                             <p class="text-sm text-white text-center font-medium">다크 모드 감성</p>
                             <p class="text-xs text-gray-400 mt-1">2025.11.05</p>
                         </div>
-                        <div class="static-theme-item bg-gradient-to-br from-[#4ECDC4] to-[#E0F7F6] rounded-2xl p-6 aspect-square flex flex-col items-center justify-center hover:scale-105 transition-transform cursor-pointer">
-                            <div class="text-6xl mb-3">🍃</div>
-                            <p class="text-sm text-gray-800 text-center font-medium">시원한 민트 브리즈</p>
-                            <p class="text-xs text-gray-600 mt-1">2025.06.18</p>
-                        </div>
                     </th:block>
                 </div>
             </div>
@@ -63,7 +68,8 @@
                 </div>
                 <div class="grid grid-cols-4 gap-4">
                     <th:block th:each="emoticon : ${purchasedEmoticons}">
-                        <div th:class="${emoticon.isActive} ? 'relative bg-[#FCE8E3] rounded-2xl p-5 aspect-square flex flex-col items-center justify-center border-4 border-[#F5A5A5] hover:scale-105 transition-transform cursor-pointer' : 'bg-white border-2 border-gray-200 rounded-2xl p-5 aspect-square flex flex-col items-center justify-center hover:scale-105 transition-transform cursor-pointer'">
+                        <div th:onclick="|equipItem(${emoticon.id})|"
+                             th:class="${emoticon.isActive} ? 'relative bg-[#FCE8E3] rounded-2xl p-5 aspect-square flex flex-col items-center justify-center border-4 border-[#F5A5A5] cursor-pointer' : 'bg-white border-2 border-gray-200 rounded-2xl p-5 aspect-square flex flex-col items-center justify-center hover:scale-105 transition-transform cursor-pointer'">
                             <div th:if="${emoticon.isActive}" class="absolute top-1 right-1 px-2 py-0.5 bg-[#F5A5A5] text-white text-xs rounded-full">사용 중</div>
                             <div class="text-5xl mb-2" th:text="${emoticon.image}">🐶</div>
                             <p class="text-xs text-gray-800 text-center font-medium" th:text="${emoticon.name}">이모티콘</p>
@@ -82,16 +88,6 @@
                             <p class="text-xs text-gray-800 text-center font-medium">월급날 기분 최고</p>
                             <p class="text-xs text-gray-500 mt-1">2026.01.12</p>
                         </div>
-                        <div class="static-emoticon-item bg-white border-2 border-gray-200 rounded-2xl p-5 aspect-square flex flex-col items-center justify-center hover:scale-105 transition-transform cursor-pointer">
-                            <div class="text-5xl mb-2">🐰</div>
-                            <p class="text-xs text-gray-800 text-center font-medium">귀요미 토끼 세트</p>
-                            <p class="text-xs text-gray-500 mt-1">2026.04.05</p>
-                        </div>
-                        <div class="static-emoticon-item bg-white border-2 border-gray-200 rounded-2xl p-5 aspect-square flex flex-col items-center justify-center hover:scale-105 transition-transform cursor-pointer">
-                            <div class="text-5xl mb-2">🐻</div>
-                            <p class="text-xs text-gray-800 text-center font-medium">행복한 곰돌이 친구들</p>
-                            <p class="text-xs text-gray-500 mt-1">2026.05.01</p>
-                        </div>
                     </th:block>
                 </div>
             </div>
@@ -102,10 +98,33 @@
 
 <th:block th:replace="~{common/layout/footer :: footer}"></th:block>
 
-<script>
+<script th:inline="javascript">
     window.addEventListener('DOMContentLoaded', () => {
       lucide.createIcons();
     });
+
+    function equipItem(invId) {
+        if(!confirm('해당 아이템을 장착하시겠습니까?')) return;
+
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = '/mypage/items/equip';
+
+        const csrf = document.createElement('input');
+        csrf.type = 'hidden';
+        csrf.name = '_csrf';
+        csrf.value = /*[[${_csrf.token}]]*/ '';
+        form.appendChild(csrf);
+
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'itemId';
+        input.value = invId;
+        form.appendChild(input);
+
+        document.body.appendChild(form);
+        form.submit();
+    }
 </script>
 <th:block th:replace="~{common/layout/header :: scripts}"></th:block>
 </body>

--- a/src/main/resources/templates/domain/mypage/profile.html
+++ b/src/main/resources/templates/domain/mypage/profile.html
@@ -157,7 +157,22 @@
 <th:block th:replace="~{common/layout/footer :: footer}"></th:block>
 
 <script>
-    window.addEventListener('DOMContentLoaded', () => { lucide.createIcons(); });
+    function formatPhone(input) {
+      const digits = input.value.replace(/[^0-9]/g, '').slice(0, 11);
+      if (digits.length < 4)       input.value = digits;
+      else if (digits.length < 8)  input.value = digits.slice(0, 3) + '-' + digits.slice(3);
+      else                         input.value = digits.slice(0, 3) + '-' + digits.slice(3, 7) + '-' + digits.slice(7);
+    }
+
+    window.addEventListener('DOMContentLoaded', () => {
+        lucide.createIcons();
+
+        // 🔥 [추가됨] 페이지 렌더링 즉시 서버에서 가져온 초기 전화번호에 하이픈 포맷 적용
+        const phoneInput = document.getElementById('profilePhone');
+        if (phoneInput && phoneInput.value) {
+            formatPhone(phoneInput);
+        }
+    });
 
     function togglePw(inputId, iconId) {
       const input = document.getElementById(inputId);
@@ -170,13 +185,6 @@
         icon.setAttribute('data-lucide', 'eye');
       }
       lucide.createIcons();
-    }
-
-    function formatPhone(input) {
-      const digits = input.value.replace(/[^0-9]/g, '').slice(0, 11);
-      if (digits.length < 4)       input.value = digits;
-      else if (digits.length < 8)  input.value = digits.slice(0, 3) + '-' + digits.slice(3);
-      else                         input.value = digits.slice(0, 3) + '-' + digits.slice(3, 7) + '-' + digits.slice(7);
     }
 
     function validatePasswordForm() {
@@ -239,7 +247,6 @@
         }
     }
 
-    // 파일 업로드 시 클라이언트 측 동적 이미지 프리뷰 반영 로직
     function previewImage(input) {
         if (input.files && input.files[0]) {
             const file = input.files[0];

--- a/src/main/resources/templates/domain/mypage/withdrawal.html
+++ b/src/main/resources/templates/domain/mypage/withdrawal.html
@@ -70,12 +70,12 @@
 
             <div id="withdrawalStep-password" class="bg-white rounded-3xl shadow-sm p-8 hidden">
                 <h2 class="text-xl text-gray-800 mb-6">비밀번호 재입력</h2>
-                <p class="text-gray-600 mb-6">본인 확인을 위해 비밀번호를 입력해주세요</p>
+                <p class="text-gray-600 mb-6">보안을 위해 비밀번호를 다시 한번 입력해주세요</p>
                 <div class="mb-6">
                     <label class="block text-sm text-gray-600 mb-2">비밀번호</label>
                     <div class="relative">
                         <input type="password" id="withdrawalPw" placeholder="비밀번호를 입력하세요"
-                               onkeypress="if(event.key==='Enter' && this.value) goToWithdrawalStep('notice')"
+                               onkeypress="if(event.key==='Enter') verifyPasswordAndProceed()"
                                class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-[#FCE8E3] focus:outline-none transition-colors pr-12"/>
                         <button type="button" onclick="togglePw('withdrawalPw','eyeWithdrawal')"
                                 class="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600">
@@ -83,7 +83,7 @@
                         </button>
                     </div>
                 </div>
-                <button onclick="if(document.getElementById('withdrawalPw').value) goToWithdrawalStep('notice')"
+                <button onclick="verifyPasswordAndProceed()"
                         class="w-full py-3 bg-[#FCE8E3] text-gray-800 rounded-xl hover:bg-[#FBD5CE] transition-colors font-medium">확인</button>
             </div>
 
@@ -118,7 +118,8 @@
                     </div>
                 </div>
                 <form th:action="@{/mypage/withdraw}" method="post">
-                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <input type="hidden" id="csrfToken" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                    <input type="hidden" id="finalPassword" name="password" value=""/>
                     <button type="submit" onclick="return handleFinalWithdrawal(event)"
                             class="w-full py-4 bg-red-500 text-white rounded-xl hover:bg-red-600 transition-colors shadow-lg font-bold text-lg">회원 탈퇴하기</button>
                 </form>
@@ -186,6 +187,46 @@
     function hideAccountModal() {
       document.getElementById('accountModalOverlay').classList.add('hidden');
       document.getElementById('accountModal').classList.add('hidden');
+    }
+
+    // 🔥 [추가] AJAX 기반 실시간 비밀번호 검증 로직
+    async function verifyPasswordAndProceed() {
+        const pwInput = document.getElementById('withdrawalPw');
+        const pw = pwInput.value;
+        if (!pw) {
+            alert('비밀번호를 입력해주세요.');
+            pwInput.focus();
+            return;
+        }
+
+        const csrfToken = document.getElementById('csrfToken').value;
+
+        try {
+            const response = await fetch('/mypage/verify-password', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: new URLSearchParams({
+                    password: pw,
+                    _csrf: csrfToken
+                })
+            });
+
+            const result = await response.json();
+
+            if (result.success) {
+                // 성공 시 백엔드 2차 검증을 위해 hidden input에 값 이관 후 다음 뷰로 전환
+                document.getElementById('finalPassword').value = pw;
+                goToWithdrawalStep('notice');
+            } else {
+                alert('비밀번호가 일치하지 않습니다. 다시 확인해주세요.');
+                pwInput.value = '';
+                pwInput.focus();
+            }
+        } catch (error) {
+            alert('서버 통신 중 오류가 발생했습니다.');
+        }
     }
 
     function handleFinalWithdrawal(e) {


### PR DESCRIPTION
## 📌 PR 목적
마이페이지 내 가장 중요한 금융 도메인인 **'모임 통장 해지 시 기여도 비례 정산'** 로직과 **'안전한 회원 탈퇴'** 프로세스를 완성했습니다.

 - Closes : #110 

## 🛠️ 주요 작업 내용
**1. 기여도 기반 정산 알고리즘 도입 (`AccountService`)**
- 기존 1/N 하드코딩 로직을 제거하고, `totalDeposit`(누적 입금액)을 기준으로 실제 입금 비율에 맞춰 잔액을 1원 단위로 정확히 분배하여 주계좌로 환급하도록 구현했습니다.
- 단수(자투리) 금액 발생 시 오차 없이 정산되도록 보정 로직을 추가했습니다.

**2. 해지 동의 2-Step 프로세스 확립 (`AccountMember`, `AccountService`)**
- 1인 연결 상태: 파트너 동의 없이 즉시 해지(`CLOSED`) 및 정산 처리됩니다.
- 2인 연결 상태: 한 명이 요청하면 `agreeClose` 상태를 관리하여 '대기 상태(PENDING)'로 진입하며, 파트너 동의 시 최종 정산 및 해지되도록 안전장치를 마련했습니다.

**3. 회원 탈퇴 2중 보안 및 검증 (`MemberService`, `MypageViewController`)**
- 해지되지 않은 활성(ACCEPT) 상태의 공동 계좌가 존재할 경우 탈퇴 뷰 진입 및 처리를 차단합니다.
- 탈퇴 시 AJAX 통신을 활용한 1차 비밀번호 실시간 검증 및 백엔드 2차 검증(이중 잠금)을 적용했습니다.
- 회원 엔티티 소프트 딜리트(`deactivate`) 및 즉시 세션 무효화(`invalidate`)를 처리했습니다.

**4. UI 데이터 연동 및 버그 수정**
- `close-account.html`: 하드코딩된 송금 내역을 걷어내고, 서버에서 넘겨받은 실제 총 송금액과 계산된 기여도(%)를 UI 모달에 동적으로 바인딩했습니다.
- 마이페이지 사이드바 스크롤 잘림 현상(`sticky` CSS 충돌)을 수정했습니다.