### PR TITLE
[FEAT] 연결 계좌 심화 관리 (한도/비밀번호 변경, 내역 다운로드, 증명서 발급) 구현

### DIFF
--- a/src/main/java/com/intelliJ_JO/modam/domain/account/entity/Account.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/account/entity/Account.java
@@ -133,4 +133,9 @@ public class Account {
             this.acctAlias = accountAlias;
         }
     }
+
+    // 🔥 [추가됨] 비밀번호 변경을 위한 헬퍼 메서드
+    public void updatePassword(String newPasswordHash) {
+        this.passwordHash = newPasswordHash;
+    }
 }

--- a/src/main/java/com/intelliJ_JO/modam/domain/account/service/AccountService.java
+++ b/src/main/java/com/intelliJ_JO/modam/domain/account/service/AccountService.java
@@ -273,4 +273,19 @@ public class AccountService {
         groupAccount.updateBalance(-totalBalance);
         groupAccount.close();
     }
+
+    // 🔥 [추가됨] 계좌 비밀번호 변경 비즈니스 로직
+    @Transactional
+    public void updateAccountPassword(Long accountId, String currentPassword, String newPassword) {
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 계좌입니다."));
+
+        // 기존 비밀번호가 맞는지 BCrypt 검증
+        if (!passwordEncoder.matches(currentPassword, account.getPasswordHash())) {
+            throw new IllegalArgumentException("기존 계좌 비밀번호가 일치하지 않습니다.");
+        }
+
+        // 새 비밀번호 암호화 후 업데이트
+        account.updatePassword(passwordEncoder.encode(newPassword));
+    }
 }

--- a/src/main/java/com/intelliJ_JO/modam/global/view/MypageViewController.java
+++ b/src/main/java/com/intelliJ_JO/modam/global/view/MypageViewController.java
@@ -1,7 +1,7 @@
 package com.intelliJ_JO.modam.global.view;
 
 import com.intelliJ_JO.modam.config.security.CustomUserDetails;
-import com.intelliJ_JO.modam.domain.account.dto.AccountUpdateRequestDto; // 🔥 DTO 임포트 추가
+import com.intelliJ_JO.modam.domain.account.dto.AccountUpdateRequestDto;
 import com.intelliJ_JO.modam.domain.account.entity.Account;
 import com.intelliJ_JO.modam.domain.account.entity.AccountMember;
 import com.intelliJ_JO.modam.domain.account.entity.InviteStatus;
@@ -16,9 +16,14 @@ import com.intelliJ_JO.modam.domain.member.entity.Member;
 import com.intelliJ_JO.modam.domain.member.repository.MemberRepository;
 import com.intelliJ_JO.modam.domain.member.service.MemberService;
 import com.intelliJ_JO.modam.domain.member.service.MyPageService;
+import com.intelliJ_JO.modam.domain.transaction.dto.TransactionResponseDto;
+import com.intelliJ_JO.modam.domain.transaction.service.TransactionService;
 import com.intelliJ_JO.modam.global.util.AES256Util;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
@@ -45,6 +50,7 @@ public class MypageViewController {
     private final CardRepository cardRepository;
     private final AES256Util aes256Util;
     private final AccountService accountService;
+    private final TransactionService transactionService; // 🔥 추가됨
 
     @ModelAttribute("cardIssueSession")
     public CardIssueSessionDto cardIssueSession() {
@@ -105,7 +111,7 @@ public class MypageViewController {
     }
 
     // =========================================================================
-    // 2. 연결 계좌 관리 (이체 한도 변경 API 추가)
+    // 2. 연결 계좌 관리
     // =========================================================================
     @GetMapping("/mypage/accounts")
     public String accountsPage(@AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
@@ -115,7 +121,6 @@ public class MypageViewController {
         return "domain/mypage/accounts";
     }
 
-    // 🔥 [추가됨] 이체 한도 변경 폼 전송을 처리하는 POST API
     @PostMapping("/mypage/accounts/limit")
     public String updateAccountLimit(
             @RequestParam(required = false) Long onceTransferLimit,
@@ -124,19 +129,15 @@ public class MypageViewController {
             RedirectAttributes rttr) {
         try {
             Long memberId = userDetails.getMember().getId();
-
-            // 현재 회원의 활성화된 커플 통장 찾기
             Long accountId = accountMemberRepository.findByMemberId(memberId).stream()
                     .filter(am -> am.getInviteStatus() == InviteStatus.ACCEPT && "GROUP".equals(am.getAccount().getAccountType().name()))
                     .findFirst().orElseThrow(() -> new IllegalArgumentException("활성 공동 계좌가 존재하지 않습니다."))
                     .getAccount().getId();
 
-            // 기존에 만들어둔 DTO 재활용
             AccountUpdateRequestDto requestDto = new AccountUpdateRequestDto();
             requestDto.setOnceTransferLimit(onceTransferLimit);
             requestDto.setDailyTransferLimit(dailyTransferLimit);
 
-            // 기존 AccountService의 업데이트 로직 호출
             accountService.updateAccount(accountId, requestDto);
 
             rttr.addFlashAttribute("successMsg", "이체 한도가 성공적으로 변경되었습니다.");
@@ -144,6 +145,112 @@ public class MypageViewController {
             rttr.addFlashAttribute("errorMsg", "이체 한도 변경 중 오류가 발생했습니다: " + e.getMessage());
         }
         return "redirect:/mypage/accounts";
+    }
+
+    @PostMapping("/mypage/accounts/password")
+    public String updateAccountPassword(
+            @RequestParam String currentPassword,
+            @RequestParam String newPassword,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            RedirectAttributes rttr) {
+        try {
+            Long memberId = userDetails.getMember().getId();
+            Long accountId = accountMemberRepository.findByMemberId(memberId).stream()
+                    .filter(am -> am.getInviteStatus() == InviteStatus.ACCEPT && "GROUP".equals(am.getAccount().getAccountType().name()))
+                    .findFirst().orElseThrow(() -> new IllegalArgumentException("활성 공동 계좌가 존재하지 않습니다."))
+                    .getAccount().getId();
+
+            accountService.updateAccountPassword(accountId, currentPassword, newPassword);
+
+            rttr.addFlashAttribute("successMsg", "계좌 비밀번호가 안전하게 변경되었습니다.");
+        } catch (Exception e) {
+            rttr.addFlashAttribute("errorMsg", "비밀번호 변경 실패: " + e.getMessage());
+        }
+        return "redirect:/mypage/accounts";
+    }
+
+    @PostMapping("/mypage/accounts/verify-password")
+    @ResponseBody
+    public java.util.Map<String, Boolean> verifyAccountPassword(@RequestParam String password, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        try {
+            Long memberId = userDetails.getMember().getId();
+            Long accountId = accountMemberRepository.findByMemberId(memberId).stream()
+                    .filter(am -> am.getInviteStatus() == InviteStatus.ACCEPT && "GROUP".equals(am.getAccount().getAccountType().name()))
+                    .findFirst().orElseThrow(() -> new IllegalArgumentException("활성 공동 계좌가 존재하지 않습니다."))
+                    .getAccount().getId();
+
+            accountService.verifyAccountPassword(accountId, password);
+            return java.util.Map.of("success", true);
+        } catch (Exception e) {
+            return java.util.Map.of("success", false);
+        }
+    }
+
+    // 🔥 [추가됨] 거래 내역 CSV 엑셀 다운로드 API
+    @GetMapping("/mypage/accounts/transactions/download")
+    public ResponseEntity<String> downloadTransactionsCsv(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        try {
+            Long memberId = userDetails.getMember().getId();
+            Long accountId = accountMemberRepository.findByMemberId(memberId).stream()
+                    .filter(am -> am.getInviteStatus() == InviteStatus.ACCEPT && "GROUP".equals(am.getAccount().getAccountType().name()))
+                    .findFirst().orElseThrow(() -> new IllegalArgumentException("활성 공동 계좌가 존재하지 않습니다."))
+                    .getAccount().getId();
+
+            // 넉넉하게 최근 1000건 조회
+            List<TransactionResponseDto> transactions = transactionService.getTransactions(accountId, null, 1000);
+
+            StringBuilder csvBuilder = new StringBuilder();
+
+            // 엑셀에서 한글이 깨지지 않도록 UTF-8 BOM 추가
+            csvBuilder.append('\ufeff');
+
+            // CSV 헤더 (컬럼명)
+            csvBuilder.append("거래일자,거래시간,구분,거래처(카테고리),거래금액\n");
+
+            // 데이터 바인딩
+            for (TransactionResponseDto tx : transactions) {
+                String typeStr = "deposit".equals(tx.getType()) ? "입금" : "출금";
+                String place = tx.getMerchant() != null ? tx.getMerchant() : tx.getCategory();
+                // 콤마(,)가 포함된 상호명이 있을 경우를 대비해 띄어쓰기로 치환
+                place = place != null ? place.replace(",", " ") : "";
+
+                csvBuilder.append(tx.getDate()).append(",")
+                        .append(tx.getTime()).append(",")
+                        .append(typeStr).append(",")
+                        .append(place).append(",")
+                        .append(tx.getAmount()).append("\n");
+            }
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=modam_transactions.csv");
+            headers.setContentType(MediaType.parseMediaType("text/csv; charset=UTF-8"));
+
+            return ResponseEntity.ok()
+                    .headers(headers)
+                    .body(csvBuilder.toString());
+
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body("다운로드 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    // 🔥 [추가됨] 계좌 증명서 발급 라우터
+    @GetMapping("/mypage/accounts/certificate")
+    public String accountCertificate(@AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
+        Member freshMember = getFreshMember(userDetails.getMember().getId());
+        populateAccountData(freshMember, model);
+
+        model.addAttribute("userName", freshMember.getName());
+
+        AccountMember myMembership = accountMemberRepository.findByMemberId(freshMember.getId()).stream()
+                .filter(am -> am.getInviteStatus() == InviteStatus.ACCEPT && "GROUP".equals(am.getAccount().getAccountType().name()))
+                .findFirst().orElse(null);
+
+        if (myMembership != null) {
+            model.addAttribute("createdAt", myMembership.getAccount().getCreatedAt());
+        }
+
+        return "domain/mypage/certificate";
     }
 
     // =========================================================================
@@ -385,7 +492,6 @@ public class MypageViewController {
             model.addAttribute("hasActiveAccount", true);
             model.addAttribute("isAccountClosed", isClosed);
 
-            // 🔥 [추가됨] 계좌 한도 정보 추출
             model.addAttribute("onceLimit", account.getOnceTransferLimit());
             model.addAttribute("dailyLimit", account.getDailyTransferLimit());
 
@@ -467,7 +573,6 @@ public class MypageViewController {
             model.addAttribute("myContribution", 0.0);
             model.addAttribute("partnerContribution", 0.0);
 
-            // 🔥 [추가됨] 한도 정보 초기화
             model.addAttribute("onceLimit", null);
             model.addAttribute("dailyLimit", null);
         }

--- a/src/main/resources/templates/domain/mypage/accounts.html
+++ b/src/main/resources/templates/domain/mypage/accounts.html
@@ -67,10 +67,20 @@
           </div>
           <div class="flex items-center justify-between p-5 bg-[#FAFAFA] rounded-2xl border border-gray-100">
             <span class="text-gray-600 font-medium">계좌 상태</span>
-            <div class="flex items-center gap-2 px-3 py-1 bg-green-100 text-green-700 rounded-full">
-              <div th:class="${accountNumber != null and accountNumber != ''} ? 'w-2 h-2 bg-green-500 rounded-full' : 'w-2 h-2 bg-gray-400 rounded-full'"></div>
-              <span class="font-bold text-sm" th:text="${accountNumber != null and accountNumber != '' ? '정상 운용 중' : '미개설'}">정상</span>
-            </div>
+            <th:block>
+              <div th:if="${accountNumber == null or accountNumber == ''}" class="flex items-center gap-2 px-3 py-1 bg-gray-100 text-gray-600 rounded-full">
+                <div class="w-2 h-2 bg-gray-400 rounded-full"></div>
+                <span class="font-bold text-sm">미개설</span>
+              </div>
+              <div th:if="${accountNumber != null and accountNumber != '' and !isAccountClosed}" class="flex items-center gap-2 px-3 py-1 bg-green-100 text-green-700 rounded-full">
+                <div class="w-2 h-2 bg-green-500 rounded-full"></div>
+                <span class="font-bold text-sm">정상 운용 중</span>
+              </div>
+              <div th:if="${accountNumber != null and accountNumber != '' and isAccountClosed}" class="flex items-center gap-2 px-3 py-1 bg-red-100 text-red-700 rounded-full">
+                <div class="w-2 h-2 bg-red-500 rounded-full"></div>
+                <span class="font-bold text-sm">해지 완료</span>
+              </div>
+            </th:block>
           </div>
         </div>
       </div>
@@ -79,22 +89,25 @@
         <h2 class="text-lg font-bold text-gray-800 mb-6 flex items-center gap-2">
           <i data-lucide="settings-2" class="w-5 h-5 text-[#F5A5A5]"></i> 계좌 관리
         </h2>
+
         <div class="grid grid-cols-2 gap-4">
           <button onclick="showLimitModal()" class="py-5 bg-[#FCE8E3] text-gray-800 rounded-2xl hover:bg-[#FBD5CE] transition-colors font-semibold flex flex-col items-center gap-2 group border border-[#F5A5A5]/20">
             <i data-lucide="arrow-up-down" class="w-6 h-6 text-[#F5A5A5] group-hover:scale-110 transition-transform"></i>
             이체한도 변경
           </button>
 
-          <button onclick="alert('계좌 비밀번호 변경 기능은 준비 중입니다.')" class="py-5 bg-[#FAFAFA] text-gray-700 rounded-2xl hover:bg-gray-100 transition-colors font-medium flex flex-col items-center gap-2 border border-gray-200">
-            <i data-lucide="lock" class="w-6 h-6 text-gray-400"></i>
+          <button onclick="showPwModal()" class="py-5 bg-[#FCE8E3] text-gray-800 rounded-2xl hover:bg-[#FBD5CE] transition-colors font-semibold flex flex-col items-center gap-2 group border border-[#F5A5A5]/20">
+            <i data-lucide="lock" class="w-6 h-6 text-[#F5A5A5] group-hover:scale-110 transition-transform"></i>
             계좌 비밀번호 변경
           </button>
-          <button onclick="alert('거래 내역 다운로드 서비스는 준비 중입니다.')" class="py-5 bg-[#FAFAFA] text-gray-700 rounded-2xl hover:bg-gray-100 transition-colors font-medium flex flex-col items-center gap-2 border border-gray-200">
-            <i data-lucide="download" class="w-6 h-6 text-gray-400"></i>
+
+          <button onclick="location.href='/mypage/accounts/transactions/download'" class="py-5 bg-[#FCE8E3] text-gray-800 rounded-2xl hover:bg-[#FBD5CE] transition-colors font-semibold flex flex-col items-center gap-2 group border border-[#F5A5A5]/20">
+            <i data-lucide="download" class="w-6 h-6 text-[#F5A5A5] group-hover:scale-110 transition-transform"></i>
             거래 내역 다운로드
           </button>
-          <button onclick="alert('계좌 증명서 발급 서비스는 준비 중입니다.')" class="py-5 bg-[#FAFAFA] text-gray-700 rounded-2xl hover:bg-gray-100 transition-colors font-medium flex flex-col items-center gap-2 border border-gray-200">
-            <i data-lucide="file-text" class="w-6 h-6 text-gray-400"></i>
+
+          <button onclick="window.open('/mypage/accounts/certificate', '_blank', 'width=850,height=900')" class="py-5 bg-[#FCE8E3] text-gray-800 rounded-2xl hover:bg-[#FBD5CE] transition-colors font-semibold flex flex-col items-center gap-2 group border border-[#F5A5A5]/20">
+            <i data-lucide="file-text" class="w-6 h-6 text-[#F5A5A5] group-hover:scale-110 transition-transform"></i>
             계좌 증명서 발급
           </button>
         </div>
@@ -121,7 +134,7 @@
     </div>
 
     <div class="p-8">
-      <form th:action="@{/mypage/accounts/limit}" method="post" id="limitForm" onsubmit="return validateLimitForm()">
+      <form th:action="@{/mypage/accounts/limit}" method="post" id="limitForm" onsubmit="return validateLimitForm(event)">
         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
 
         <div class="space-y-6 mb-8">
@@ -131,10 +144,12 @@
               <span class="text-xs text-[#F5A5A5] bg-[#FCE8E3] px-2 py-1 rounded-md">현재: <span th:text="${onceLimit != null ? #numbers.formatInteger(onceLimit, 0, 'COMMA') : '제한 없음'}">1,000,000</span>원</span>
             </div>
             <div class="relative">
-              <input type="number" id="newOnceLimit" name="onceTransferLimit"
-                     th:value="${onceLimit}"
-                     placeholder="금액을 입력하세요 (숫자만)"
+              <input type="text" id="displayOnceLimit"
+                     th:value="${onceLimit != null ? #numbers.formatInteger(onceLimit, 0, 'COMMA') : ''}"
+                     oninput="formatNumberInput(this, 'realOnceLimit')"
+                     placeholder="금액을 입력하세요"
                      class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-[#F5A5A5] focus:ring-0 focus:outline-none transition-colors text-gray-800 font-medium bg-gray-50 focus:bg-white"/>
+              <input type="hidden" id="realOnceLimit" name="onceTransferLimit" th:value="${onceLimit}" />
               <span class="absolute right-4 top-1/2 -translate-y-1/2 text-gray-500 font-medium">원</span>
             </div>
           </div>
@@ -145,10 +160,12 @@
               <span class="text-xs text-[#F5A5A5] bg-[#FCE8E3] px-2 py-1 rounded-md">현재: <span th:text="${dailyLimit != null ? #numbers.formatInteger(dailyLimit, 0, 'COMMA') : '제한 없음'}">5,000,000</span>원</span>
             </div>
             <div class="relative">
-              <input type="number" id="newDailyLimit" name="dailyTransferLimit"
-                     th:value="${dailyLimit}"
-                     placeholder="금액을 입력하세요 (숫자만)"
+              <input type="text" id="displayDailyLimit"
+                     th:value="${dailyLimit != null ? #numbers.formatInteger(dailyLimit, 0, 'COMMA') : ''}"
+                     oninput="formatNumberInput(this, 'realDailyLimit')"
+                     placeholder="금액을 입력하세요"
                      class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-[#F5A5A5] focus:ring-0 focus:outline-none transition-colors text-gray-800 font-medium bg-gray-50 focus:bg-white"/>
+              <input type="hidden" id="realDailyLimit" name="dailyTransferLimit" th:value="${dailyLimit}" />
               <span class="absolute right-4 top-1/2 -translate-y-1/2 text-gray-500 font-medium">원</span>
             </div>
             <p id="limitErrorMsg" class="hidden text-xs text-red-500 mt-2 font-medium">⚠️ 1회 이체 한도는 1일 이체 한도를 초과할 수 없습니다.</p>
@@ -164,6 +181,58 @@
   </div>
 </div>
 
+<div id="pwModalOverlay" class="hidden fixed inset-0 bg-black/50 backdrop-blur-sm z-40 transition-opacity" onclick="hidePwModal()"></div>
+<div id="pwModal" class="hidden fixed inset-0 z-50 flex items-center justify-center p-4">
+  <div class="bg-white rounded-3xl shadow-2xl w-full max-w-md overflow-hidden">
+    <div class="bg-gradient-to-r from-[#FCE8E3] to-[#FFE4E8] px-8 py-6 flex items-center justify-between border-b border-[#F5A5A5]/20">
+      <div class="flex items-center gap-3">
+        <div class="w-10 h-10 bg-white rounded-full flex items-center justify-center shadow-sm">
+          <i data-lucide="lock" class="w-5 h-5 text-[#F5A5A5]"></i>
+        </div>
+        <h2 class="text-xl font-bold text-gray-800">계좌 비밀번호 변경</h2>
+      </div>
+      <button onclick="hidePwModal()" class="text-gray-500 hover:text-gray-800 transition-colors">
+        <i data-lucide="x" class="w-6 h-6"></i>
+      </button>
+    </div>
+
+    <div class="p-8">
+      <form th:action="@{/mypage/accounts/password}" method="post" id="pwForm" onsubmit="validatePwForm(event)">
+        <input type="hidden" name="_csrf" th:value="${_csrf.token}"/>
+
+        <div class="space-y-6 mb-8">
+          <div>
+            <label class="block text-sm font-bold text-gray-700 mb-2">기존 계좌 비밀번호 (4자리)</label>
+            <input type="password" id="currentPassword" name="currentPassword" maxlength="4" pattern="\d{4}" required
+                   placeholder="****"
+                   class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-[#F5A5A5] focus:ring-0 focus:outline-none transition-colors text-center tracking-widest text-2xl bg-gray-50 focus:bg-white"/>
+          </div>
+
+          <div>
+            <label class="block text-sm font-bold text-gray-700 mb-2">새 계좌 비밀번호 (4자리 숫자)</label>
+            <input type="password" id="newPassword" name="newPassword" maxlength="4" pattern="\d{4}" required
+                   placeholder="****"
+                   class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-[#F5A5A5] focus:ring-0 focus:outline-none transition-colors text-center tracking-widest text-2xl bg-gray-50 focus:bg-white"/>
+          </div>
+
+          <div>
+            <label class="block text-sm font-bold text-gray-700 mb-2">새 계좌 비밀번호 확인</label>
+            <input type="password" id="confirmPassword" maxlength="4" pattern="\d{4}" required
+                   placeholder="****"
+                   class="w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-[#F5A5A5] focus:ring-0 focus:outline-none transition-colors text-center tracking-widest text-2xl bg-gray-50 focus:bg-white"/>
+            <p id="pwErrorMsg" class="hidden text-xs text-red-500 mt-2 font-medium">⚠️ 에러 메시지</p>
+          </div>
+        </div>
+
+        <div class="flex gap-3">
+          <button type="button" onclick="hidePwModal()" class="flex-1 py-4 bg-gray-100 text-gray-700 rounded-xl hover:bg-gray-200 transition-colors font-bold text-lg">취소</button>
+          <button type="submit" class="flex-1 py-4 bg-[#F5A5A5] text-white rounded-xl hover:bg-[#F28B8B] transition-colors shadow-md font-bold text-lg">비밀번호 변경</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
 <th:block th:replace="~{common/layout/footer :: footer}"></th:block>
 
 <script>
@@ -171,36 +240,105 @@
     lucide.createIcons();
   });
 
-  // 모달 제어 로직
+  function formatNumberInput(input, hiddenId) {
+      let value = input.value.replace(/[^0-9]/g, '');
+      if (value === '') {
+          document.getElementById(hiddenId).value = '';
+          input.value = '';
+          return;
+      }
+      document.getElementById(hiddenId).value = value;
+      input.value = parseInt(value, 10).toLocaleString('ko-KR');
+  }
+
   function showLimitModal() {
       document.getElementById('limitModalOverlay').classList.remove('hidden');
       document.getElementById('limitModal').classList.remove('hidden');
   }
-
   function hideLimitModal() {
       document.getElementById('limitModalOverlay').classList.add('hidden');
       document.getElementById('limitModal').classList.add('hidden');
   }
 
-  // 한도 폼 검증 로직 (1회 한도가 1일 한도보다 클 수 없음)
-  function validateLimitForm() {
-      const onceLimitInput = document.getElementById('newOnceLimit').value;
-      const dailyLimitInput = document.getElementById('newDailyLimit').value;
+  function validateLimitForm(event) {
+      const onceLimitInput = document.getElementById('realOnceLimit').value;
+      const dailyLimitInput = document.getElementById('realDailyLimit').value;
       const errorMsg = document.getElementById('limitErrorMsg');
 
-      // 둘 다 입력되었을 때만 비교
       if (onceLimitInput && dailyLimitInput) {
           const once = parseInt(onceLimitInput, 10);
           const daily = parseInt(dailyLimitInput, 10);
 
           if (once > daily) {
               errorMsg.classList.remove('hidden');
-              document.getElementById('newOnceLimit').classList.add('border-red-400', 'bg-red-50');
-              document.getElementById('newDailyLimit').classList.add('border-red-400', 'bg-red-50');
-              return false; // 폼 전송 막음
+              document.getElementById('displayOnceLimit').classList.add('border-red-400', 'bg-red-50');
+              document.getElementById('displayDailyLimit').classList.add('border-red-400', 'bg-red-50');
+              if (event) event.preventDefault();
+              return false;
           }
       }
-      return true; // 정상 전송
+      return true;
+  }
+
+  function showPwModal() {
+      document.getElementById('pwModalOverlay').classList.remove('hidden');
+      document.getElementById('pwModal').classList.remove('hidden');
+  }
+  function hidePwModal() {
+      document.getElementById('pwModalOverlay').classList.add('hidden');
+      document.getElementById('pwModal').classList.add('hidden');
+      document.getElementById('pwForm').reset();
+      document.getElementById('pwErrorMsg').classList.add('hidden');
+      document.getElementById('newPassword').classList.remove('border-red-400', 'bg-red-50');
+      document.getElementById('confirmPassword').classList.remove('border-red-400', 'bg-red-50');
+      document.getElementById('currentPassword').classList.remove('border-red-400', 'bg-red-50');
+  }
+
+  async function validatePwForm(event) {
+      event.preventDefault();
+
+      const currentPw = document.getElementById('currentPassword');
+      const newPw = document.getElementById('newPassword');
+      const confirmPw = document.getElementById('confirmPassword');
+      const errorMsg = document.getElementById('pwErrorMsg');
+
+      if (newPw.value !== confirmPw.value) {
+          errorMsg.textContent = '⚠️ 새 비밀번호가 일치하지 않습니다.';
+          errorMsg.classList.remove('hidden');
+          newPw.classList.add('border-red-400', 'bg-red-50');
+          confirmPw.classList.add('border-red-400', 'bg-red-50');
+          currentPw.classList.remove('border-red-400', 'bg-red-50');
+          return false;
+      }
+
+      const csrfToken = document.querySelector('input[name="_csrf"]').value;
+
+      try {
+          const response = await fetch('/mypage/accounts/verify-password', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+              body: new URLSearchParams({
+                  password: currentPw.value,
+                  _csrf: csrfToken
+              })
+          });
+
+          const result = await response.json();
+
+          if (result.success) {
+              document.getElementById('pwForm').submit();
+          } else {
+              errorMsg.textContent = '⚠️ 기존 계좌 비밀번호가 일치하지 않습니다.';
+              errorMsg.classList.remove('hidden');
+              currentPw.classList.add('border-red-400', 'bg-red-50');
+              newPw.classList.remove('border-red-400', 'bg-red-50');
+              confirmPw.classList.remove('border-red-400', 'bg-red-50');
+              currentPw.value = '';
+              currentPw.focus();
+          }
+      } catch (error) {
+          alert('서버 통신 중 오류가 발생했습니다.');
+      }
   }
 </script>
 <th:block th:replace="~{common/layout/header :: scripts}"></th:block>

--- a/src/main/resources/templates/domain/mypage/certificate.html
+++ b/src/main/resources/templates/domain/mypage/certificate.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>계좌 개설 확인서 - 모담</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        /* 프린트(PDF) 출력 시 설정 */
+        @media print {
+            body { -webkit-print-color-adjust: exact; print-color-adjust: exact; background-color: white !important; }
+            .no-print { display: none !important; }
+            /* A4 용지에 맞게 인쇄 여백 강제 고정 */
+            @page { size: A4 portrait; margin: 15mm; }
+        }
+    </style>
+</head>
+<body class="bg-gray-100 flex justify-center min-h-screen py-10 print:py-0 print:bg-white">
+
+<div class="no-print fixed top-6 right-8 z-50">
+    <button onclick="window.print()" class="bg-[#F5A5A5] hover:bg-[#F28B8B] text-white font-bold py-3 px-6 rounded-full shadow-lg transition-colors flex items-center gap-2">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="6 9 6 2 18 2 18 9"></polyline>
+            <path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"></path>
+            <rect width="12" height="8" x="6" y="14"></rect>
+        </svg>
+        인쇄 / PDF 저장
+    </button>
+</div>
+
+<div class="bg-white w-[800px] p-10 shadow-2xl rounded-sm border border-gray-200 relative print:shadow-none print:border-none">
+
+    <div class="absolute inset-0 flex items-center justify-center opacity-5 pointer-events-none">
+        <span class="text-9xl font-black rotate-[-30deg]">MODAM</span>
+    </div>
+
+    <div class="relative z-10">
+        <div class="flex justify-between items-end border-b-2 border-gray-800 pb-4 mb-6">
+            <div>
+                <h1 class="text-4xl font-black text-gray-900 tracking-tight">계좌 개설 확인서</h1>
+                <p class="text-gray-500 mt-2">Account Certificate</p>
+            </div>
+            <div class="text-right">
+                <p class="text-xl font-bold text-[#F5A5A5] tracking-widest">MODAM BANK</p>
+                <p class="text-sm text-gray-600 mt-1">발급일: <span th:text="${#temporals.format(#temporals.createNow(), 'yyyy년 MM월 dd일')}">2026년 01월 01일</span></p>
+            </div>
+        </div>
+
+        <div class="bg-gray-50 border border-gray-200 p-8 mb-8">
+            <table class="w-full text-left">
+                <tbody>
+                <tr class="border-b border-gray-200">
+                    <th class="py-3 w-1/3 text-gray-600 font-bold">계좌번호 (Account No.)</th>
+                    <td class="py-3 text-xl font-mono font-bold text-gray-900" th:text="${accountNumber}">5050-12345678-012</td>
+                </tr>
+                <tr class="border-b border-gray-200">
+                    <th class="py-3 w-1/3 text-gray-600 font-bold">상품명 (Product)</th>
+                    <td class="py-3 text-lg font-bold text-gray-900">모담(MODAM) 커플 모임 통장</td>
+                </tr>
+                <tr class="border-b border-gray-200">
+                    <th class="py-3 w-1/3 text-gray-600 font-bold">개설일 (Open Date)</th>
+                    <td class="py-3 text-lg text-gray-800" th:text="${#temporals.format(createdAt, 'yyyy년 MM월 dd일')}">2026년 01월 15일</td>
+                </tr>
+                <tr class="border-b border-gray-200">
+                    <th class="py-3 w-1/3 text-gray-600 font-bold">공동 예금주 (Account Holders)</th>
+                    <td class="py-3 text-lg font-bold text-gray-900">
+                        <span th:text="${userName}">원석</span> <span class="text-gray-500 font-normal mx-1">및</span> <span th:text="${partnerName != null ? partnerName : '(연결 대기 중)'}">파트너</span>
+                    </td>
+                </tr>
+                <tr>
+                    <th class="py-3 w-1/3 text-gray-600 font-bold">현재 잔액 (Balance)</th>
+                    <td class="py-3 text-xl font-bold text-[#F5A5A5]">₩ <span th:text="${accountBalance != null ? #numbers.formatInteger(accountBalance, 0, 'COMMA') : '0'}">0</span></td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="text-center mb-10 mt-6">
+            <p class="text-2xl font-bold text-gray-800 leading-loose">
+                위 계좌가 당행에 정상적으로 개설되어<br>
+                안전하게 운용 중임을 증명합니다.
+            </p>
+            <p class="text-gray-500 mt-3 text-sm">This is to certify that the above account has been opened and is in good standing.</p>
+        </div>
+
+        <div class="flex justify-end items-center mr-8">
+            <div class="text-right mr-6">
+                <p class="text-lg text-gray-600 font-medium">모담(MODAM) 은행장</p>
+                <p class="text-2xl font-black tracking-widest mt-2">김 모 담</p>
+            </div>
+            <div class="w-20 h-20 rounded-full border-4 border-red-600 text-red-600 flex items-center justify-center opacity-90 transform -rotate-12">
+                <span class="text-2xl font-black">모담<br>은행</span>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    window.onload = function() {
+        // 창이 열리자마자 브라우저 인쇄(PDF 저장) 다이얼로그 호출
+        setTimeout(() => {
+            window.print();
+        }, 500);
+    };
+</script>
+</body>
+</html>


### PR DESCRIPTION
### 🎯 작업 개요
마이페이지의 '연결 계좌' 도메인에서 제공되는 4가지 심화 계좌 관리 기능(이체 한도 변경, 계좌 비밀번호 변경, 거래 내역 CSV 다운로드, 계좌 개설 확인서 발급)을 모두 구현하여 사용자 편의성과 서비스 완성도를 높였습니다.

 - Closes : #128 

### 💡 주요 작업 내용
* **이체 한도 변경 기능 구현**
  1회 및 1일 이체 한도를 변경할 수 있는 모달 UI를 추가했습니다. 입력 시 자동으로 콤마(,)가 포매팅되며, 1회 한도가 1일 한도를 초과하지 못하도록 프론트엔드 검증 로직을 적용했습니다.

* **계좌 비밀번호 변경 (AJAX 이중 보안)**
  새로운 비밀번호(4자리) 설정 시, 기존 계좌 비밀번호를 AJAX로 서버에 전송하여 실시간으로 일치 여부를 검증(`verifyAccountPassword`)하도록 설계하여 보안성을 대폭 강화했습니다.

* **거래 내역 CSV 다운로드 기능**
  `TransactionService`를 통해 해당 계좌의 전체 거래 내역을 조회하고, 이를 엑셀에서 즉시 열어볼 수 있는 CSV 포맷(UTF-8 BOM 적용)으로 변환하여 다운로드하는 API를 구현했습니다.

* **계좌 개설 확인서 (PDF/인쇄) 발급 기능**
  실제 은행과 유사한 워터마크와 직인이 포함된 증명서 전용 HTML(`certificate.html`)을 팝업으로 제공합니다. 화면 렌더링 즉시 브라우저의 인쇄(`window.print()`) 기능을 호출하여 손쉽게 PDF 저장 및 출력이 가능하도록 구현했습니다.

* **기타 UI/UX 개선**
  계좌 관리의 4가지 주요 기능 버튼의 디자인(색상, 호버 액션)을 통일하여 시각적 안정감을 주었으며, 계좌 해지 상태(`isAccountClosed`)에 따라 계좌 상태 배지가 동적으로 변환되도록 컨트롤러와 뷰를 수정했습니다.